### PR TITLE
chore: renovate ignores x/net

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,5 +10,8 @@
   "semanticCommits": true,
   "postUpdateOptions": [
     "gomodTidy"
+  ],
+  "ignoreDeps": [
+      "golang.org/x/net"
   ]
 }


### PR DESCRIPTION
As soon as we support Go 1.15 as the oldest, we can remove this.