### PR TITLE
fix!: use singular name for package

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -25,7 +25,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"cloud.google.com/go/cloudsqlconn/errtypes"
+	"cloud.google.com/go/cloudsqlconn/errtype"
 	"cloud.google.com/go/cloudsqlconn/internal/cloudsql"
 	"cloud.google.com/go/cloudsqlconn/internal/trace"
 	"github.com/google/uuid"
@@ -197,14 +197,14 @@ func (d *Dialer) Dial(ctx context.Context, instance string, opts ...DialOption) 
 	if err != nil {
 		// refresh the instance info in case it caused the connection failure
 		i.ForceRefresh()
-		return nil, errtypes.NewDialError("failed to dial", i.String(), err)
+		return nil, errtype.NewDialError("failed to dial", i.String(), err)
 	}
 	if c, ok := conn.(*net.TCPConn); ok {
 		if err := c.SetKeepAlive(true); err != nil {
-			return nil, errtypes.NewDialError("failed to set keep-alive", i.String(), err)
+			return nil, errtype.NewDialError("failed to set keep-alive", i.String(), err)
 		}
 		if err := c.SetKeepAlivePeriod(cfg.tcpKeepAlive); err != nil {
-			return nil, errtypes.NewDialError("failed to set keep-alive period", i.String(), err)
+			return nil, errtype.NewDialError("failed to set keep-alive period", i.String(), err)
 		}
 	}
 	tlsConn := tls.Client(conn, tlsCfg)
@@ -212,7 +212,7 @@ func (d *Dialer) Dial(ctx context.Context, instance string, opts ...DialOption) 
 		// refresh the instance info in case it caused the handshake failure
 		i.ForceRefresh()
 		_ = tlsConn.Close() // best effort close attempt
-		return nil, errtypes.NewDialError("handshake failed", i.String(), err)
+		return nil, errtype.NewDialError("handshake failed", i.String(), err)
 	}
 	latency := time.Since(startTime).Milliseconds()
 	go func() {

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/cloudsqlconn/errtypes"
+	"cloud.google.com/go/cloudsqlconn/errtype"
 	"cloud.google.com/go/cloudsqlconn/internal/mock"
 )
 
@@ -93,7 +93,7 @@ func TestDialWithAdminAPIErrors(t *testing.T) {
 	d.sqladmin = svc
 
 	_, err = d.Dial(context.Background(), "bad-instance-name")
-	var wantErr1 *errtypes.ConfigError
+	var wantErr1 *errtype.ConfigError
 	if !errors.As(err, &wantErr1) {
 		t.Fatalf("when instance name is invalid, want = %T, got = %v", wantErr1, err)
 	}
@@ -107,7 +107,7 @@ func TestDialWithAdminAPIErrors(t *testing.T) {
 	}
 
 	_, err = d.Dial(context.Background(), "my-project:my-region:my-instance")
-	var wantErr2 *errtypes.RefreshError
+	var wantErr2 *errtype.RefreshError
 	if !errors.As(err, &wantErr2) {
 		t.Fatalf("when API call fails, want = %T, got = %v", wantErr2, err)
 	}
@@ -139,13 +139,13 @@ func TestDialWithConfigurationErrors(t *testing.T) {
 	}()
 
 	_, err = d.Dial(context.Background(), "my-project:my-region:my-instance", WithPrivateIP())
-	var wantErr1 *errtypes.ConfigError
+	var wantErr1 *errtype.ConfigError
 	if !errors.As(err, &wantErr1) {
 		t.Fatalf("when IP type is invalid, want = %T, got = %v", wantErr1, err)
 	}
 
 	_, err = d.Dial(context.Background(), "my-project:my-region:my-instance")
-	var wantErr2 *errtypes.DialError
+	var wantErr2 *errtype.DialError
 	if !errors.As(err, &wantErr2) {
 		t.Fatalf("when server proxy socket is unavailable, want = %T, got = %v", wantErr2, err)
 	}

--- a/errtype/doc.go
+++ b/errtype/doc.go
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package errtypes provides a number of concrete types which are used by the
+// Package errtype provides a number of concrete types which are used by the
 // cloudsqlconn package.
-package errtypes // import "cloud.google.com/go/cloudsqlconn/errtypes"
+package errtype // import "cloud.google.com/go/cloudsqlconn/errtype"

--- a/errtype/errors.go
+++ b/errtype/errors.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package errtypes
+package errtype
 
 import "fmt"
 

--- a/errtype/errors_test.go
+++ b/errtype/errors_test.go
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package errtypes_test
+package errtype_test
 
 import (
 	"errors"
 	"testing"
 
-	"cloud.google.com/go/cloudsqlconn/errtypes"
+	"cloud.google.com/go/cloudsqlconn/errtype"
 )
 
 func TestErrorFormatting(t *testing.T) {
@@ -29,22 +29,22 @@ func TestErrorFormatting(t *testing.T) {
 	}{
 		{
 			desc: "config error message",
-			err:  errtypes.NewConfigError("error message", "proj:reg:inst"),
+			err:  errtype.NewConfigError("error message", "proj:reg:inst"),
 			want: "Config error: error message (connection name = \"proj:reg:inst\")",
 		},
 		{
 			desc: "refresh error message without internal error",
-			err:  errtypes.NewRefreshError("error message", "proj:reg:inst", nil),
+			err:  errtype.NewRefreshError("error message", "proj:reg:inst", nil),
 			want: "Refresh error: error message (connection name = \"proj:reg:inst\")",
 		},
 		{
 			desc: "refresh error message with internal error",
-			err:  errtypes.NewRefreshError("error message", "proj:reg:inst", errors.New("inner-error")),
+			err:  errtype.NewRefreshError("error message", "proj:reg:inst", errors.New("inner-error")),
 			want: "Refresh error: error message (connection name = \"proj:reg:inst\"): inner-error",
 		},
 		{
 			desc: "Dial error without inner error",
-			err: errtypes.NewDialError(
+			err: errtype.NewDialError(
 				"message",
 				"proj:reg:inst",
 				nil, // no error here
@@ -53,7 +53,7 @@ func TestErrorFormatting(t *testing.T) {
 		},
 		{
 			desc: "Dial error with inner error",
-			err: errtypes.NewDialError(
+			err: errtype.NewDialError(
 				"message",
 				"proj:reg:inst",
 				errors.New("inner-error"),

--- a/internal/cloudsql/instance.go
+++ b/internal/cloudsql/instance.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	"cloud.google.com/go/cloudsqlconn/errtypes"
+	errtype "cloud.google.com/go/cloudsqlconn/errtype"
 	"golang.org/x/oauth2"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
@@ -56,7 +56,7 @@ func parseConnName(cn string) (connName, error) {
 	b := []byte(cn)
 	m := connNameRegex.FindSubmatch(b)
 	if m == nil {
-		err := errtypes.NewConfigError(
+		err := errtype.NewConfigError(
 			"invalid instance connection name, expected PROJECT:REGION:INSTANCE",
 			cn,
 		)
@@ -191,7 +191,7 @@ func (i *Instance) ConnectInfo(ctx context.Context, ipType string) (string, *tls
 	}
 	addr, ok := res.md.ipAddrs[ipType]
 	if !ok {
-		err := errtypes.NewConfigError(
+		err := errtype.NewConfigError(
 			fmt.Sprintf("instance does not have IP of type %q", ipType),
 			i.String(),
 		)

--- a/internal/cloudsql/instance_test.go
+++ b/internal/cloudsql/instance_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/cloudsqlconn/errtypes"
+	"cloud.google.com/go/cloudsqlconn/errtype"
 	"cloud.google.com/go/cloudsqlconn/internal/mock"
 )
 
@@ -165,7 +165,7 @@ func TestConnectInfoErrors(t *testing.T) {
 	}
 
 	_, _, err = im.ConnectInfo(ctx, PublicIP)
-	var wantErr *errtypes.DialError
+	var wantErr *errtype.DialError
 	if !errors.As(err, &wantErr) {
 		t.Fatalf("when connect info fails, want = %T, got = %v", wantErr, err)
 	}

--- a/internal/cloudsql/refresh_test.go
+++ b/internal/cloudsql/refresh_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/cloudsqlconn/errtypes"
+	"cloud.google.com/go/cloudsqlconn/errtype"
 	"cloud.google.com/go/cloudsqlconn/internal/mock"
 	"golang.org/x/oauth2"
 )
@@ -118,7 +118,7 @@ func TestRefreshFailsFast(t *testing.T) {
 	ctx, _ = context.WithTimeout(context.Background(), time.Millisecond)
 	_, _, _, err = r.performRefresh(ctx, cn, RSAKey)
 
-	var wantErr *errtypes.DialError
+	var wantErr *errtype.DialError
 	if !errors.As(err, &wantErr) {
 		t.Fatalf("when refresh is throttled, want = %T, got = %v", wantErr, err)
 	}
@@ -254,14 +254,14 @@ func TestRefreshWithFailedMetadataCall(t *testing.T) {
 		{
 			req: mock.CreateEphemeralSuccess(
 				mock.NewFakeCSQLInstance(cn.project, cn.region, cn.name), 1),
-			wantErr: &errtypes.RefreshError{},
+			wantErr: &errtype.RefreshError{},
 			desc:    "When the Metadata call fails",
 		},
 		{
 			req: mock.InstanceGetSuccess(
 				mock.NewFakeCSQLInstance(cn.project, cn.region, cn.name,
 					mock.WithRegion("some-other-region")), 1),
-			wantErr: &errtypes.RefreshError{},
+			wantErr: &errtype.RefreshError{},
 			desc:    "When the region does not match",
 		},
 		{
@@ -271,7 +271,7 @@ func TestRefreshWithFailedMetadataCall(t *testing.T) {
 					mock.WithRegion("my-region"),
 					mock.WithFirstGenBackend(),
 				), 1),
-			wantErr: &errtypes.ConfigError{},
+			wantErr: &errtype.ConfigError{},
 			desc:    "When the instance isn't Second generation",
 		},
 		{
@@ -281,7 +281,7 @@ func TestRefreshWithFailedMetadataCall(t *testing.T) {
 					mock.WithRegion("my-region"),
 					mock.WithMissingIPAddrs(),
 				), 1),
-			wantErr: &errtypes.ConfigError{},
+			wantErr: &errtype.ConfigError{},
 			desc:    "When the instance has no supported IP addresses",
 		},
 		{
@@ -293,7 +293,7 @@ func TestRefreshWithFailedMetadataCall(t *testing.T) {
 						return nil, nil
 					}),
 				), 1),
-			wantErr: &errtypes.RefreshError{},
+			wantErr: &errtype.RefreshError{},
 			desc:    "When the server cert does not decode",
 		},
 		{
@@ -310,7 +310,7 @@ func TestRefreshWithFailedMetadataCall(t *testing.T) {
 						return certPEM.Bytes(), nil
 					}),
 				), 1),
-			wantErr: &errtypes.RefreshError{},
+			wantErr: &errtype.RefreshError{},
 			desc:    "When the cert is not a valid X.509 cert",
 		},
 	}
@@ -346,7 +346,7 @@ func TestRefreshWithFailedEphemeralCertCall(t *testing.T) {
 	}{
 		{
 			reqs:    []*mock.Request{mock.InstanceGetSuccess(inst, 1)}, // no ephemeral cert call registered
-			wantErr: &errtypes.RefreshError{},
+			wantErr: &errtype.RefreshError{},
 			desc:    "When the CreateEphemeralCert call fails",
 		},
 		{
@@ -359,7 +359,7 @@ func TestRefreshWithFailedEphemeralCertCall(t *testing.T) {
 							}),
 					), 1),
 			},
-			wantErr: &errtypes.RefreshError{},
+			wantErr: &errtype.RefreshError{},
 			desc:    "When decoding the cert fails", // SQL Admin API fail
 		},
 		{
@@ -377,7 +377,7 @@ func TestRefreshWithFailedEphemeralCertCall(t *testing.T) {
 							}),
 					), 1),
 			},
-			wantErr: &errtypes.RefreshError{},
+			wantErr: &errtype.RefreshError{},
 			desc:    "When parsing the cert fails", // SQL Admin API fail
 		},
 	}
@@ -459,7 +459,7 @@ func TestRefreshBuildsTLSConfig(t *testing.T) {
 	}
 
 	err = verifyPeerCert(nil, nil)
-	var wantErr *errtypes.DialError
+	var wantErr *errtype.DialError
 	if !errors.As(err, &wantErr) {
 		t.Fatalf("when verify peer cert fails, want = %T, got = %v", wantErr, err)
 	}

--- a/options.go
+++ b/options.go
@@ -22,7 +22,7 @@ import (
 	"net/http"
 	"time"
 
-	"cloud.google.com/go/cloudsqlconn/errtypes"
+	"cloud.google.com/go/cloudsqlconn/errtype"
 	"cloud.google.com/go/cloudsqlconn/internal/cloudsql"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -61,7 +61,7 @@ func WithCredentialsFile(filename string) Option {
 	return func(d *dialerConfig) {
 		b, err := ioutil.ReadFile(filename)
 		if err != nil {
-			d.err = errtypes.NewConfigError(err.Error(), "n/a")
+			d.err = errtype.NewConfigError(err.Error(), "n/a")
 			return
 		}
 		opt := WithCredentialsJSON(b)
@@ -75,7 +75,7 @@ func WithCredentialsJSON(b []byte) Option {
 	return func(d *dialerConfig) {
 		c, err := google.CredentialsFromJSON(context.Background(), b, sqladmin.SqlserviceAdminScope)
 		if err != nil {
-			d.err = errtypes.NewConfigError(err.Error(), "n/a")
+			d.err = errtype.NewConfigError(err.Error(), "n/a")
 			return
 		}
 		d.tokenSource = c.TokenSource


### PR DESCRIPTION
> In go, package names are not plural. This is surprising to programmers who came from other languages and are retaining an old habit of pluralizing names. Don’t name a package httputils, but httputil!

See https://rakyll.org/style-packages.