### PR TITLE
feat!: update version policy to latest 3 versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,8 +299,8 @@ considered unsupported.
 
 ## Supported Go Versions
 
-We support the latest four Go versions. Changes in supported Go versions will be
-considered a minor change.
+We test and support at minimum, the latest three Go versions. Changes in supported Go versions will be
+considered a minor change, and will be listed in the realease notes. 
 
 ### Release cadence
 This project aims for a release on at least a monthly basis. If no new features


### PR DESCRIPTION
Update version policy to match [google-cloud-go](https://github.com/googleapis/google-cloud-go#go-versions-supported). 