### PR TITLE
chore: close listener after context cancellation

### DIFF
--- a/internal/mock/cloudsql.go
+++ b/internal/mock/cloudsql.go
@@ -296,7 +296,6 @@ func StartServerProxy(t *testing.T, i FakeCSQLInstance) func() {
 			default:
 				conn, err := ln.Accept()
 				if err != nil {
-					t.Logf("fake server proxy will close listener after error: %v", err)
 					return
 				}
 				conn.Write([]byte(i.name))
@@ -305,7 +304,7 @@ func StartServerProxy(t *testing.T, i FakeCSQLInstance) func() {
 		}
 	}()
 	return func() {
-		ln.Close()
 		cancel()
+		ln.Close()
 	}
 }


### PR DESCRIPTION
Also, remove log line that was causing a race condition.