### PR TITLE
feat: expose the WithQuotaProject dialer option

### DIFF
--- a/options.go
+++ b/options.go
@@ -139,6 +139,14 @@ func WithAdminAPIEndpoint(url string) Option {
 	}
 }
 
+// WithQuotaProject allows you to change the gcloud project used to track the
+// api request quota.
+func WithQuotaProject(p string) Option {
+	return func(cfg *dialerConfig) {
+		cfg.sqladminOpts = append(cfg.sqladminOpts, apiopt.WithQuotaProject(p))
+	}
+}
+
 // WithDialFunc configures the function used to connect to the address on the
 // named network. This option is generally unnecessary except for advanced
 // use-cases.

--- a/options.go
+++ b/options.go
@@ -139,8 +139,7 @@ func WithAdminAPIEndpoint(url string) Option {
 	}
 }
 
-// WithQuotaProject allows you to change the gcloud project used to track the
-// api request quota.
+// WithQuotaProject returns an Option that specifies the project used for quota and billing purposes.
 func WithQuotaProject(p string) Option {
 	return func(cfg *dialerConfig) {
 		cfg.sqladminOpts = append(cfg.sqladminOpts, apiopt.WithQuotaProject(p))


### PR DESCRIPTION
This option is available as google.golang.org/api/option to the
gcloud go api. It needs to be exposed in the cloud sql connector
also.