### PR TITLE
chore: fix flaky test

### DIFF
--- a/dialer_test.go
+++ b/dialer_test.go
@@ -1,11 +1,11 @@
 // Copyright 2021 Google LLC
-
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"syscall"
 	"testing"
-	"time"
 
 	"cloud.google.com/go/cloudsqlconn/errtype"
 	"cloud.google.com/go/cloudsqlconn/internal/mock"
@@ -163,7 +162,8 @@ func TestDialWithAdminAPIErrors(t *testing.T) {
 
 func TestDialWithConfigurationErrors(t *testing.T) {
 	inst := mock.NewFakeCSQLInstance("my-project", "my-region", "my-instance",
-		mock.WithCertExpiry(time.Now().Add(-time.Hour)))
+		mock.WithServerName("not-the-server-youre-looking-for"),
+	)
 
 	// Don't use the cleanup function. Because this test is about error
 	// cases, API requests (started in two separate goroutines) will


### PR DESCRIPTION
This commit adds an option to configure the proxy server's common name
and provides a reliable test for dial errors.