### PR TITLE
chore: enable Flakybot to monitor test builds

### DIFF
--- a/.github/flakybot.yaml
+++ b/.github/flakybot.yaml
@@ -1,0 +1,15 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+issuePriority: p2

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -73,3 +73,15 @@
 - name: 'tests: run'
   color: 3DED97
   description: Label to trigger Github Action tests.
+
+- name: 'flakybot: flaky'
+  color: 86d9d7
+  description: Tells the Flaky Bot not to close or comment on this issue.
+
+- name: 'flakybot: quiet'
+  color: 86d9d7
+  description: Tells the Flaky Bot to comment less.
+
+- name: 'flakybot: issue'
+  color: a9f9f7
+  description: An issue filed by the Flaky Bot. Should not be added manually.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -108,7 +108,31 @@ jobs:
           SQLSERVER_USER: '${{ steps.secrets.outputs.SQLSERVER_USER }}'
           SQLSERVER_PASS: '${{ steps.secrets.outputs.SQLSERVER_PASS }}'
           SQLSERVER_DB: '${{ steps.secrets.outputs.SQLSERVER_DB }}'
-        run: go test -v -race -cover ./e2e_mysql_test.go ./e2e_postgres_test.go ./e2e_sqlserver_test.go
+        run: |
+          go install github.com/jstemmer/go-junit-report/v2@latest
+          go test -v -race -cover ./e2e_mysql_test.go ./e2e_postgres_test.go ./e2e_sqlserver_test.go | tee test_results.txt
+          go-junit-report -in test_results.txt -set-exit-code -out integration_sponge_log.xml
+        
+      - name: FlakyBot (Linux)
+        # only run flakybot on periodic (schedule) and continuous (push) events
+        if: ${{ (github.event_name == 'pull_request' || github.event_name == 'push') && runner.os == 'Linux' && always() }}
+        run: |
+          curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot -o flakybot -s -L
+          chmod +x ./flakybot
+          ./flakybot --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      - name: FlakyBot (Windows)
+        # only run flakybot on periodic (schedule) and continuous (push) events
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Windows' && always() }}
+        run: |
+          curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot.exe -o flakybot.exe -s -L
+          ./flakybot.exe --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      - name: FlakyBot (macOS)
+        # only run flakybot on periodic (schedule) and continuous (push) events
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'macOS' && always() }}
+        run: |
+          curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot-darwin-amd64 -o flakybot -s -L
+          chmod +x ./flakybot
+          ./flakybot --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
 
   unit:
     # run job on proper workflow event triggers (skip job for pull_request event from forks and only run pull_request_target for "tests: run" label)  

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -115,7 +115,7 @@ jobs:
         
       - name: FlakyBot (Linux)
         # only run flakybot on periodic (schedule) and continuous (push) events
-        if: ${{ (github.event_name == 'pull_request' || github.event_name == 'push') && runner.os == 'Linux' && always() }}
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Linux' && always() }}
         run: |
           curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot -o flakybot -s -L
           chmod +x ./flakybot
@@ -148,9 +148,28 @@ jobs:
           - os: macos-latest
             goarch: "386"
       fail-fast: false
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     env:
       GOARCH: ${{ matrix.goarch }}
     steps:
+      - name: Remove PR label
+        if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                name: 'tests: run',
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number
+              });
+            } catch (e) {
+              console.log('Failed to remove label. Another job may have already removed it!');
+            }
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v3
         with:
@@ -160,12 +179,44 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v0.8.1'
+        with:
+          workload_identity_provider: ${{ secrets.PROVIDER_NAME }}
+          service_account: ${{ secrets.SERVICE_ACCOUNT }}
+          access_token_lifetime: 600s
       - name: Run tests
         if: matrix.goarch == ''
         run: |
-          go test -v -race -cover -short ./...
+          go install github.com/jstemmer/go-junit-report/v2@latest
+          go test -v -race -cover -short ./... | tee test_results.txt
+          go-junit-report -in test_results.txt -set-exit-code -out unit_sponge_log.xml
       - name: Run tests (386)
         # 386 archs don't support race detector
         if: matrix.goarch == '386'
         run: |
-          go test -v -cover -short ./...
+          go install github.com/jstemmer/go-junit-report/v2@latest
+          go test -v -cover -short ./... | tee test_results.txt
+          go-junit-report -in test_results.txt -set-exit-code -out unit_sponge_log.xml
+      
+      - name: FlakyBot (Linux)
+        # only run flakybot on periodic (schedule) and continuous (push) events
+        if: ${{ (github.event_name == 'pull_request' || github.event_name == 'push') && runner.os == 'Linux' && always() }}
+        run: |
+          curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot -o flakybot -s -L
+          chmod +x ./flakybot
+          ./flakybot --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      - name: FlakyBot (Windows)
+        # only run flakybot on periodic (schedule) and continuous (push) events
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Windows' && always() }}
+        run: |
+          curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot.exe -o flakybot.exe -s -L
+          ./flakybot.exe --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      - name: FlakyBot (macOS)
+        # only run flakybot on periodic (schedule) and continuous (push) events
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'macOS' && always() }}
+        run: |
+          curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot-darwin-amd64 -o flakybot -s -L
+          chmod +x ./flakybot
+          ./flakybot --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -196,10 +196,7 @@ jobs:
         # 386 archs don't support race detector
         if: matrix.goarch == '386'
         run: |
-          go install github.com/jstemmer/go-junit-report/v2@latest
-          go test -v -cover -short ./... | tee test_results.txt
-          go-junit-report -in test_results.txt -set-exit-code -out unit_sponge_log.xml
-      
+          go test -v -cover -short ./...      
       - name: FlakyBot (Linux)
         # only run flakybot on periodic (schedule) and continuous (push) events
         if: ${{ (github.event_name == 'pull_request' || github.event_name == 'push') && runner.os == 'Linux' && always() }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -199,7 +199,7 @@ jobs:
           go test -v -cover -short ./...      
       - name: FlakyBot (Linux)
         # only run flakybot on periodic (schedule) and continuous (push) events
-        if: ${{ (github.event_name == 'pull_request' || github.event_name == 'push') && runner.os == 'Linux' && always() }}
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Linux' && always() }}
         run: |
           curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot -o flakybot -s -L
           chmod +x ./flakybot

--- a/e2e_postgres_test.go
+++ b/e2e_postgres_test.go
@@ -153,10 +153,6 @@ func TestPostgresHook(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping Postgres integration tests")
 	}
-	// throw error
-	if true {
-		panic("THROWING ERROR FOR FLAKYBOT TO CATCH")
-	}
 	testConn := func(db *sql.DB) {
 		var now time.Time
 		if err := db.QueryRow("SELECT NOW()").Scan(&now); err != nil {

--- a/e2e_postgres_test.go
+++ b/e2e_postgres_test.go
@@ -153,6 +153,10 @@ func TestPostgresHook(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping Postgres integration tests")
 	}
+	// throw error
+	if true {
+		panic("THROWING ERROR FOR FLAKYBOT TO CATCH")
+	}
 	testConn := func(db *sql.DB) {
 		var now time.Time
 		if err := db.QueryRow("SELECT NOW()").Scan(&now); err != nil {


### PR DESCRIPTION
Enabling Flakybot on test builds (excluding `386` architecture unit tests).

Example flakybot created issue #299 