### PR TITLE
chore: explicitly set workflow shell to bash

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -108,6 +108,8 @@ jobs:
           SQLSERVER_USER: '${{ steps.secrets.outputs.SQLSERVER_USER }}'
           SQLSERVER_PASS: '${{ steps.secrets.outputs.SQLSERVER_PASS }}'
           SQLSERVER_DB: '${{ steps.secrets.outputs.SQLSERVER_DB }}'
+        # specifying bash shell ensures a failure in a piped process isn't lost by using `set -eo pipefail`
+        shell: bash
         run: |
           go install github.com/jstemmer/go-junit-report/v2@latest
           go test -v -race -cover ./e2e_mysql_test.go ./e2e_postgres_test.go ./e2e_sqlserver_test.go | tee test_results.txt
@@ -188,6 +190,8 @@ jobs:
           access_token_lifetime: 600s
       - name: Run tests
         if: matrix.goarch == ''
+        # specifying bash shell ensures a failure in a piped process isn't lost by using `set -eo pipefail`
+        shell: bash
         run: |
           go install github.com/jstemmer/go-junit-report/v2@latest
           go test -v -race -cover -short ./... | tee test_results.txt


### PR DESCRIPTION
Setting test shell to bash to catch errors prior to pipe.