### PR TITLE
chore: add convert XML step to workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -114,7 +114,7 @@ jobs:
           go test -v -race -cover ./e2e_mysql_test.go ./e2e_postgres_test.go ./e2e_sqlserver_test.go | tee test_results.txt
       
       - name: Convert test output to XML
-        if: always()
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && always() }}
         run: |
           go install github.com/jstemmer/go-junit-report/v2@latest
           go-junit-report -in test_results.txt -set-exit-code -out integration_sponge_log.xml

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -197,14 +197,17 @@ jobs:
         # specifying bash shell ensures a failure in a piped process isn't lost by using `set -eo pipefail`
         shell: bash
         run: |
-          go install github.com/jstemmer/go-junit-report/v2@latest
           go test -v -race -cover -short ./... | tee test_results.txt
-          go-junit-report -in test_results.txt -set-exit-code -out unit_sponge_log.xml
       - name: Run tests (386)
         # 386 archs don't support race detector
         if: matrix.goarch == '386'
         run: |
-          go test -v -cover -short ./...      
+          go test -v -cover -short ./...
+      - name: Convert test output to XML
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && always() && matrix.goarch == '' }}
+        run: |
+          go install github.com/jstemmer/go-junit-report/v2@latest
+          go-junit-report -in test_results.txt -set-exit-code -out unit_sponge_log.xml      
       - name: FlakyBot (Linux)
         # only run flakybot on periodic (schedule) and continuous (push) events
         if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Linux' && always() }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -112,7 +112,8 @@ jobs:
         shell: bash
         run: |
           go test -v -race -cover ./e2e_mysql_test.go ./e2e_postgres_test.go ./e2e_sqlserver_test.go | tee test_results.txt
-      - name: Convert Test to XML
+      
+      - name: Convert test output to XML
         if: always()
         run: |
           go install github.com/jstemmer/go-junit-report/v2@latest
@@ -127,7 +128,7 @@ jobs:
           ./flakybot --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
       - name: FlakyBot (Windows)
         # only run flakybot on periodic (schedule) and continuous (push) events
-        if: ${{ (github.event_name == 'pull_request' || github.event_name == 'push') && runner.os == 'Windows' && always() }}
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Windows' && always() }}
         run: |
           curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot.exe -o flakybot.exe -s -L
           ./flakybot.exe --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -111,8 +111,11 @@ jobs:
         # specifying bash shell ensures a failure in a piped process isn't lost by using `set -eo pipefail`
         shell: bash
         run: |
-          go install github.com/jstemmer/go-junit-report/v2@latest
           go test -v -race -cover ./e2e_mysql_test.go ./e2e_postgres_test.go ./e2e_sqlserver_test.go | tee test_results.txt
+      - name: Convert Test to XML
+        if: always()
+        run: |
+          go install github.com/jstemmer/go-junit-report/v2@latest
           go-junit-report -in test_results.txt -set-exit-code -out integration_sponge_log.xml
         
       - name: FlakyBot (Linux)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -124,7 +124,7 @@ jobs:
           ./flakybot --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
       - name: FlakyBot (Windows)
         # only run flakybot on periodic (schedule) and continuous (push) events
-        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Windows' && always() }}
+        if: ${{ (github.event_name == 'pull_request' || github.event_name == 'push') && runner.os == 'Windows' && always() }}
         run: |
           curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot.exe -o flakybot.exe -s -L
           ./flakybot.exe --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/e2e_postgres_test.go
+++ b/e2e_postgres_test.go
@@ -153,10 +153,6 @@ func TestPostgresHook(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping Postgres integration tests")
 	}
-	// throw error
-	if true {
-		panic("THROWING ERROR FOR FLAKYBOT TO CATCH")
-	}
 	testConn := func(db *sql.DB) {
 		var now time.Time
 		if err := db.QueryRow("SELECT NOW()").Scan(&now); err != nil {

--- a/e2e_postgres_test.go
+++ b/e2e_postgres_test.go
@@ -153,6 +153,10 @@ func TestPostgresHook(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping Postgres integration tests")
 	}
+	// throw error
+	if true {
+		panic("THROWING ERROR FOR FLAKYBOT TO CATCH")
+	}
 	testConn := func(db *sql.DB) {
 		var now time.Time
 		if err := db.QueryRow("SELECT NOW()").Scan(&now); err != nil {


### PR DESCRIPTION
Previously had
```yaml
run: |
          go install github.com/jstemmer/go-junit-report/v2@latest
          go test -race -v ./... | tee test_results.txt
          go-junit-report -in test_results.txt -set-exit-code -out
```

With new `pipefail` being set, if line that runs the test `go test -race -v ./... | tee test_results.txt` fails (i.e. a test fails) than this causes an exit code and for the line below it `go-junit-report ...` not to be run which in turn disables flakybot from working as it requires XML sponge log.

By moving the convert XML functionality to its own `step` in the workflow we can make sure it always runs no matter what happens with the tests.

