### PR TITLE
fix: handle context cancellations during instance refresh

### DIFF
--- a/internal/cloudsql/instance_test.go
+++ b/internal/cloudsql/instance_test.go
@@ -303,3 +303,32 @@ func TestRefreshDuration(t *testing.T) {
 		})
 	}
 }
+
+func TestContextCancelled(t *testing.T) {
+	ctx := context.Background()
+
+	client, cleanup, err := mock.NewSQLAdminService(ctx)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	defer cleanup()
+
+	// Set up an instance and then close it immediately
+	im, err := NewInstance("my-proj:my-region:my-inst", client, RSAKey, 30, nil, "", RefreshCfg{})
+	if err != nil {
+		t.Fatalf("failed to initialize Instance: %v", err)
+	}
+	im.Close()
+
+	// grab the current value of next before scheduling another refresh
+	next := im.next
+
+	op := im.scheduleRefresh(time.Nanosecond)
+	<-op.ready
+
+	// if scheduleRefresh returns without scheduling another one,
+	// i.next should be untouched and remain the same pointer value
+	if im.next != next {
+		t.Fatalf("refresh did not return after a closed context. next pointer changed: want = %p, got = %p", next, im.next)
+	}
+}


### PR DESCRIPTION
## Change Description

Context cancellation was being checked after the immediate retries for errored instance refreshes. This moves the check up a bit further so the background refresh process exits once the context is cancelled.

## Checklist

- [x] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform//issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [ ] Ensure the tests and linter pass
- [ ] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #370 