### PR TITLE
fix: stop default OpenCensus work on Close

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -322,6 +322,7 @@ func (d *Dialer) Close() error {
 	for _, i := range d.instances {
 		i.Close()
 	}
+	trace.Stop()
 	return nil
 }
 

--- a/internal/trace/metrics.go
+++ b/internal/trace/metrics.go
@@ -117,6 +117,11 @@ func InitMetrics() error {
 	return registerErr
 }
 
+// Stop tells OpenCensus to stop the default worker.
+func Stop() {
+	view.Stop()
+}
+
 // RecordDialLatency records a latency value for a call to dial.
 func RecordDialLatency(ctx context.Context, instance, dialerID string, latency int64) {
 	// tag.New creates a new context and errors only if the new tag already


### PR DESCRIPTION
With the recent release of OpenCensus (0.24.0), the Go connector can now stop the background worker goroutine started by OpenCensus.

Fixes #374.