### PR TITLE
fix: revert "fix: support MySQL driver’s conn check. (#226)"

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -22,13 +22,11 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	_ "embed"
-	"errors"
 	"fmt"
 	"net"
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"cloud.google.com/go/cloudsqlconn/errtype"
@@ -241,7 +239,7 @@ func (d *Dialer) Dial(ctx context.Context, instance string, opts ...DialOption) 
 		trace.RecordDialLatency(ctx, instance, d.dialerID, latency)
 	}()
 
-	return newInstrumentedConn(conn, tlsConn, func() {
+	return newInstrumentedConn(tlsConn, func() {
 		n := atomic.AddUint64(&i.OpenConns, ^uint64(0))
 		trace.RecordOpenConnections(context.Background(), int64(n), d.dialerID, i.String())
 	}), nil
@@ -275,10 +273,9 @@ func (d *Dialer) Warmup(_ context.Context, instance string, opts ...DialOption) 
 
 // newInstrumentedConn initializes an instrumentedConn that on closing will
 // decrement the number of open connects and record the result.
-func newInstrumentedConn(rawConn, conn net.Conn, closeFunc func()) *instrumentedConn {
+func newInstrumentedConn(conn net.Conn, closeFunc func()) *instrumentedConn {
 	return &instrumentedConn{
 		Conn:      conn,
-		rawConn:   rawConn,
 		closeFunc: closeFunc,
 	}
 }
@@ -287,19 +284,7 @@ func newInstrumentedConn(rawConn, conn net.Conn, closeFunc func()) *instrumented
 // is closed.
 type instrumentedConn struct {
 	net.Conn
-	// rawConn is the underlying net.Conn without TLS
-	rawConn   net.Conn
 	closeFunc func()
-}
-
-// SyscallConn supports a connection check in the MySQL driver by delegating to
-// the underlying non-TLS net.Conn.
-func (i *instrumentedConn) SyscallConn() (syscall.RawConn, error) {
-	sconn, ok := i.rawConn.(syscall.Conn)
-	if !ok {
-		return nil, errors.New("connection is not a syscall.Conn")
-	}
-	return sconn.SyscallConn()
 }
 
 // Close delegates to the underylying net.Conn interface and reports the close


### PR DESCRIPTION
This reverts commit 4b48e3bfe7a5bd8c398592f21eb25ac43644e123.

This fix was incorrect. The connection to the Cloud SQL instance is a TLS connection. A recent version of Go made it possible to access the underlying net.Conn, but noted: "writing to or reading from this connection directly will corrupt the TLS session." [1] The change here made it possible for the MySQL driver to inadvertenly read from the underlying connection. [2] Instead, we should be attempting to read from the TLS connection without corrupting it.

[1] https://pkg.go.dev/crypto/tls#Conn.NetConn.
[2] https://github.com/go-sql-driver/mysql/blob/ad9fa14acdcf7d0533e7fbe58728f3d216213ade/conncheck.go#L34