### PR TITLE
fix: remove leading slash from metric names

### DIFF
--- a/internal/trace/metrics.go
+++ b/internal/trace/metrics.go
@@ -33,33 +33,33 @@ var (
 	keyErrorCode, _ = tag.NewKey("cloudsql_error_code")
 
 	mLatencyMS = stats.Int64(
-		"/cloudsqlconn/latency",
+		"cloudsqlconn/latency",
 		"The latency in milliseconds per Dial",
 		stats.UnitMilliseconds,
 	)
 	mConnections = stats.Int64(
-		"/cloudsqlconn/connection",
+		"cloudsqlconn/connection",
 		"A connect or disconnect event to Cloud SQL",
 		stats.UnitDimensionless,
 	)
 	mDialError = stats.Int64(
-		"/cloudsqlconn/dial_failure",
+		"cloudsqlconn/dial_failure",
 		"A failure to dial a Cloud SQL instance",
 		stats.UnitDimensionless,
 	)
 	mSuccessfulRefresh = stats.Int64(
-		"/cloudsqlconn/refresh_success",
+		"cloudsqlconn/refresh_success",
 		"A successful certificate refresh operation",
 		stats.UnitDimensionless,
 	)
 	mFailedRefresh = stats.Int64(
-		"/cloudsqlconn/refresh_failure",
+		"cloudsqlconn/refresh_failure",
 		"A failed certificate refresh operation",
 		stats.UnitDimensionless,
 	)
 
 	latencyView = &view.View{
-		Name:        "/cloudsqlconn/dial_latency",
+		Name:        "cloudsqlconn/dial_latency",
 		Measure:     mLatencyMS,
 		Description: "The distribution of dialer latencies (ms)",
 		// Latency in buckets, e.g., >=0ms, >=100ms, etc.
@@ -67,28 +67,28 @@ var (
 		TagKeys:     []tag.Key{keyInstance, keyDialerID},
 	}
 	connectionsView = &view.View{
-		Name:        "/cloudsqlconn/open_connections",
+		Name:        "cloudsqlconn/open_connections",
 		Measure:     mConnections,
 		Description: "The current number of open Cloud SQL connections",
 		Aggregation: view.LastValue(),
 		TagKeys:     []tag.Key{keyInstance, keyDialerID},
 	}
 	dialFailureView = &view.View{
-		Name:        "/cloudsqlconn/dial_failure_count",
+		Name:        "cloudsqlconn/dial_failure_count",
 		Measure:     mDialError,
 		Description: "The number of failed dial attempts",
 		Aggregation: view.Count(),
 		TagKeys:     []tag.Key{keyInstance, keyDialerID},
 	}
 	refreshCountView = &view.View{
-		Name:        "/cloudsqlconn/refresh_success_count",
+		Name:        "cloudsqlconn/refresh_success_count",
 		Measure:     mSuccessfulRefresh,
 		Description: "The number of successful certificate refresh operations",
 		Aggregation: view.Count(),
 		TagKeys:     []tag.Key{keyInstance, keyDialerID},
 	}
 	failedRefreshCountView = &view.View{
-		Name:        "/cloudsqlconn/refresh_failure_count",
+		Name:        "cloudsqlconn/refresh_failure_count",
 		Measure:     mFailedRefresh,
 		Description: "The number of failed certificate refresh operations",
 		Aggregation: view.Count(),

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -54,6 +54,7 @@ func (e *spyMetricsExporter) Data() []metric {
 // wantLastValueMetric ensures the provided metrics include a metric with the
 // wanted name and at least data point.
 func wantLastValueMetric(t *testing.T, wantName string, ms []metric) {
+	t.Helper()
 	gotNames := make(map[string]view.AggregationData)
 	for _, m := range ms {
 		gotNames[m.name] = m.data
@@ -68,6 +69,7 @@ func wantLastValueMetric(t *testing.T, wantName string, ms []metric) {
 // wantDistributionMetric ensures the provided metrics include a metric with the
 // wanted name and at least one data point.
 func wantDistributionMetric(t *testing.T, wantName string, ms []metric) {
+	t.Helper()
 	gotNames := make(map[string]view.AggregationData)
 	for _, m := range ms {
 		gotNames[m.name] = m.data
@@ -82,6 +84,7 @@ func wantDistributionMetric(t *testing.T, wantName string, ms []metric) {
 // wantCountMetric ensures the provided metrics include a metric with the wanted
 // name and at least one data point.
 func wantCountMetric(t *testing.T, wantName string, ms []metric) {
+	t.Helper()
 	gotNames := make(map[string]view.AggregationData)
 	for _, m := range ms {
 		gotNames[m.name] = m.data
@@ -140,11 +143,11 @@ func TestDialerWithMetrics(t *testing.T) {
 	time.Sleep(10 * time.Millisecond) // allow exporter a chance to run
 
 	// success metrics
-	wantLastValueMetric(t, "/cloudsqlconn/open_connections", spy.Data())
-	wantDistributionMetric(t, "/cloudsqlconn/dial_latency", spy.Data())
-	wantCountMetric(t, "/cloudsqlconn/refresh_success_count", spy.Data())
+	wantLastValueMetric(t, "cloudsqlconn/open_connections", spy.Data())
+	wantDistributionMetric(t, "cloudsqlconn/dial_latency", spy.Data())
+	wantCountMetric(t, "cloudsqlconn/refresh_success_count", spy.Data())
 
 	// failure metrics from dialing bogus instance
-	wantCountMetric(t, "/cloudsqlconn/dial_failure_count", spy.Data())
-	wantCountMetric(t, "/cloudsqlconn/refresh_failure_count", spy.Data())
+	wantCountMetric(t, "cloudsqlconn/dial_failure_count", spy.Data())
+	wantCountMetric(t, "cloudsqlconn/refresh_failure_count", spy.Data())
 }


### PR DESCRIPTION
The StackDriver exporter for OpenCensus will join metric names with slashes, so this leading slash is unnecessary. Further, when it's present, Prometheus transforms it into "key_". Remove the leading slash makes for nicer metric names.

Fixes #391.