### PR TITLE
chore(ci): increase golangci-lint timeout

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -56,3 +56,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
+          args: --timeout 3m


### PR DESCRIPTION
See [#258](https://github.com/GoogleCloudPlatform/alloydb-auth-proxy/pull/258) for details