### PR TITLE
chore: update trusted-contribution.yml

### DIFF
--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -15,3 +15,5 @@
 annotations:
   - type: label
     text: "tests: run"
+
+trustedContributors: ['renovate-bot', 'gcf-merge-on-green[bot]']


### PR DESCRIPTION
Removing default `release-please[bot]` from trusted contributors as the release please app creates release PRs from internal branches and not forks like the Github Action does. This means we no longer require the label trigger on release PRs created by the app.