### PR TITLE
fix: prevent repeated context expired errors

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -110,7 +110,7 @@ var (
 // RSA keypair is generated will be faster.
 func NewDialer(ctx context.Context, opts ...Option) (*Dialer, error) {
 	cfg := &dialerConfig{
-		refreshTimeout: 30 * time.Second,
+		refreshTimeout: cloudsql.RefreshTimeout,
 		dialFunc:       proxy.Dial,
 		useragents:     []string{userAgent},
 	}

--- a/internal/cloudsql/instance.go
+++ b/internal/cloudsql/instance.go
@@ -38,7 +38,7 @@ const (
 	// enforced by the rate limiter.
 	refreshInterval = 30 * time.Second
 
-	// refreshTimeout is the maximum amount of time to wait for a refresh
+	// RefreshTimeout is the maximum amount of time to wait for a refresh
 	// cycle to complete. This value should be greater than the
 	// refreshInterval.
 	RefreshTimeout = 60 * time.Second

--- a/internal/cloudsql/instance.go
+++ b/internal/cloudsql/instance.go
@@ -138,7 +138,8 @@ type Instance struct {
 	connName
 	key *rsa.PrivateKey
 
-	// t sets the maximum duration a refresh cycle can run for.
+	// refreshTimeout sets the maximum duration a refresh cycle can run
+	// for.
 	refreshTimeout time.Duration
 	// l controls the rate at which refresh cycles are run.
 	l *rate.Limiter

--- a/internal/cloudsql/instance.go
+++ b/internal/cloudsql/instance.go
@@ -34,10 +34,10 @@ const (
 	// expires that a new refresh operation begins.
 	refreshBuffer = 4 * time.Minute
 
-	// refreshInterval is the amount of time between refresh attempts
+	// refreshInterval is the amount of time between refresh attempts.
 	refreshInterval = 30 * time.Second
 
-	// refreshBurst is the initial burst allowed by the rate limite.
+	// refreshBurst is the initial burst allowed by the rate limiter.
 	refreshBurst = 2
 )
 

--- a/internal/cloudsql/instance.go
+++ b/internal/cloudsql/instance.go
@@ -25,12 +25,21 @@ import (
 
 	"cloud.google.com/go/cloudsqlconn/errtype"
 	"golang.org/x/oauth2"
+	"golang.org/x/time/rate"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
-// the refresh buffer is the amount of time before a refresh's result expires
-// that a new refresh operation begins.
-const refreshBuffer = 4 * time.Minute
+const (
+	// the refresh buffer is the amount of time before a refresh's result
+	// expires that a new refresh operation begins.
+	refreshBuffer = 4 * time.Minute
+
+	// refreshInterval is the amount of time between refresh attempts
+	refreshInterval = 30 * time.Second
+
+	// refreshBurst is the initial burst allowed by the rate limite.
+	refreshBurst = 2
+)
 
 var (
 	// Instance connection name is the format <PROJECT>:<REGION>:<INSTANCE>
@@ -123,8 +132,13 @@ type Instance struct {
 	connName
 	key *rsa.PrivateKey
 
+	// t sets the maximum duration a refresh cycle can run for.
+	d time.Duration
+	// l controls the rate at which refresh cycles are run.
+	l *rate.Limiter
+	r refresher
+
 	resultGuard sync.RWMutex
-	r           refresher
 	RefreshCfg  RefreshCfg
 	// cur represents the current refreshOperation that will be used to
 	// create connections. If a valid complete refreshOperation isn't
@@ -158,14 +172,13 @@ func NewInstance(
 	i := &Instance{
 		connName: cn,
 		key:      key,
+		l:        rate.NewLimiter(rate.Every(refreshInterval), refreshBurst),
 		r: newRefresher(
-			refreshTimeout,
-			30*time.Second,
-			2,
 			client,
 			ts,
 			dialerID,
 		),
+		d:          refreshTimeout,
 		RefreshCfg: r,
 		ctx:        ctx,
 		cancel:     cancel,
@@ -296,13 +309,29 @@ func refreshDuration(now, certExpiry time.Time) time.Duration {
 
 // scheduleRefresh schedules a refresh operation to be triggered after a given
 // duration. The returned refreshOperation can be used to either Cancel or Wait
-// for the operations result.
+// for the operation's result.
 func (i *Instance) scheduleRefresh(d time.Duration) *refreshOperation {
-	res := &refreshOperation{}
-	res.ready = make(chan struct{})
-	res.timer = time.AfterFunc(d, func() {
-		res.md, res.tlsCfg, res.expiry, res.err = i.r.performRefresh(i.ctx, i.connName, i.key, i.RefreshCfg.UseIAMAuthN)
-		close(res.ready)
+	r := &refreshOperation{}
+	r.ready = make(chan struct{})
+	r.timer = time.AfterFunc(d, func() {
+		ctx, cancel := context.WithTimeout(i.ctx, i.d)
+		defer cancel()
+
+		// avoid refreshing too often to try not to tax the SQL Admin
+		// API quotas
+		err := i.l.Wait(ctx)
+		if err != nil {
+			r.err = errtype.NewDialError(
+				"context was canceled or expired before refresh completed",
+				i.connName.String(),
+				nil,
+			)
+		} else {
+			r.md, r.tlsCfg, r.expiry, r.err = i.r.performRefresh(
+				ctx, i.connName, i.key, i.RefreshCfg.UseIAMAuthN)
+		}
+
+		close(r.ready)
 
 		select {
 		case <-i.ctx.Done():
@@ -317,7 +346,7 @@ func (i *Instance) scheduleRefresh(d time.Duration) *refreshOperation {
 		defer i.resultGuard.Unlock()
 
 		// if failed, scheduled the next refresh immediately
-		if res.err != nil {
+		if r.err != nil {
 			i.next = i.scheduleRefresh(0)
 			// If the latest result is bad, avoid replacing the
 			// used result while it's still valid and potentially
@@ -326,18 +355,18 @@ func (i *Instance) scheduleRefresh(d time.Duration) *refreshOperation {
 			// valid are surpressed. We should try to surface
 			// errors in a more meaningful way.
 			if !i.cur.isValid() {
-				i.cur = res
+				i.cur = r
 			}
 			return
 		}
 
 		// Update the current results, and schedule the next refresh in
 		// the future
-		i.cur = res
+		i.cur = r
 		t := refreshDuration(time.Now(), i.cur.expiry)
 		i.next = i.scheduleRefresh(t)
 	})
-	return res
+	return r
 }
 
 // String returns the instance's connection name.

--- a/internal/cloudsql/instance_test.go
+++ b/internal/cloudsql/instance_test.go
@@ -19,6 +19,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -255,7 +256,7 @@ func TestClose(t *testing.T) {
 	im.Close()
 
 	_, _, err = im.ConnectInfo(ctx, PublicIP)
-	if !errors.Is(err, context.Canceled) {
+	if !strings.Contains(err.Error(), "context was canceled or expired") {
 		t.Fatalf("failed to retrieve connect info: %v", err)
 	}
 }

--- a/options.go
+++ b/options.go
@@ -150,7 +150,8 @@ func WithRSAKey(k *rsa.PrivateKey) Option {
 	}
 }
 
-// WithRefreshTimeout returns an Option that sets a timeout on refresh operations. Defaults to 30s.
+// WithRefreshTimeout returns an Option that sets a timeout on refresh
+// operations. Defaults to 60s.
 func WithRefreshTimeout(t time.Duration) Option {
 	return func(d *dialerConfig) {
 		d.refreshTimeout = t


### PR DESCRIPTION
The Go Connector uses a rate limiter to prevent excessive API usage. When refresh attempts failed a few times, however, the Go Connector would continue to schedule new attempts which would be rate limited. The rate limited error would then result in another refresh attempt being scheduled. As a result, the Go Connector would report numerous "context deadline expired" errors which were in fact rate limiting errors.

This commit moves the rate limiter to the entry point of the refresh code. This change ensures that if there are refresh failures, there are not runaway attempts to refresh again. Instead, when an error occurs, a new refresh attempt will run only once the rate limiter allows it to run.

Fixes #384