### PR TITLE
chore: performRefresh returns refreshResult

### DIFF
--- a/internal/cloudsql/instance.go
+++ b/internal/cloudsql/instance.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	// the refresh buffer is the amount of time before a refresh cycle's result
-	// expires that a new refresh operation begins.
+	// the refresh buffer is the amount of time before a refresh cycle's
+	// certificate expires that a new refresh operation begins.
 	refreshBuffer = 4 * time.Minute
 
 	// refreshInterval is the amount of time between refresh attempts as
@@ -94,10 +94,8 @@ type refreshOperation struct {
 	ready chan struct{}
 	// timer that triggers refresh, can be used to cancel.
 	timer  *time.Timer
+	result refreshResult
 	err    error
-	expiry time.Time
-	tlsCfg *tls.Config
-	md     metadata
 }
 
 // cancel prevents the instanceInfo from starting, if it hasn't already
@@ -110,12 +108,12 @@ func (r *refreshOperation) cancel() bool {
 // isValid returns true if this result is complete, successful, and is still
 // valid.
 func (r *refreshOperation) isValid() bool {
-	// verify the result has finished running
+	// verify the refreshOperation has finished running
 	select {
 	default:
 		return false
 	case <-r.ready:
-		if r.err != nil || time.Now().After(r.expiry.Round(0)) {
+		if r.err != nil || time.Now().After(r.result.expiry.Round(0)) {
 			return false
 		}
 		return true
@@ -145,7 +143,7 @@ type Instance struct {
 	l *rate.Limiter
 	r refresher
 
-	resultGuard sync.RWMutex
+	refreshLock sync.RWMutex
 	RefreshCfg  RefreshCfg
 	// cur represents the current refreshOperation that will be used to
 	// create connections. If a valid complete refreshOperation isn't
@@ -188,10 +186,10 @@ func NewInstance(
 	}
 	// For the initial refresh operation, set cur = next so that connection
 	// requests block until the first refresh is complete.
-	i.resultGuard.Lock()
+	i.refreshLock.Lock()
 	i.cur = i.scheduleRefresh(0)
 	i.next = i.cur
-	i.resultGuard.Unlock()
+	i.refreshLock.Unlock()
 	return i
 }
 
@@ -205,7 +203,7 @@ func (i *Instance) Close() {
 // private) and a TLS config that can be used to connect to a Cloud SQL
 // instance.
 func (i *Instance) ConnectInfo(ctx context.Context, ipType string) (string, *tls.Config, error) {
-	res, err := i.result(ctx)
+	op, err := i.refreshOperation(ctx)
 	if err != nil {
 		return "", nil, err
 	}
@@ -216,13 +214,13 @@ func (i *Instance) ConnectInfo(ctx context.Context, ipType string) (string, *tls
 	switch ipType {
 	case AutoIP:
 		// Try Public first
-		addr, ok = res.md.ipAddrs[PublicIP]
+		addr, ok = op.result.ipAddrs[PublicIP]
 		if !ok {
 			// Try Private second
-			addr, ok = res.md.ipAddrs[PrivateIP]
+			addr, ok = op.result.ipAddrs[PrivateIP]
 		}
 	default:
-		addr, ok = res.md.ipAddrs[ipType]
+		addr, ok = op.result.ipAddrs[ipType]
 	}
 	if !ok {
 		err := errtype.NewConfigError(
@@ -231,25 +229,25 @@ func (i *Instance) ConnectInfo(ctx context.Context, ipType string) (string, *tls
 		)
 		return "", nil, err
 	}
-	return addr, res.tlsCfg, nil
+	return addr, op.result.conf, nil
 }
 
 // InstanceEngineVersion returns the engine type and version for the instance.
 // The value corresponds to one of the following types for the instance:
 // https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1beta4/SqlDatabaseVersion
 func (i *Instance) InstanceEngineVersion(ctx context.Context) (string, error) {
-	res, err := i.result(ctx)
+	op, err := i.refreshOperation(ctx)
 	if err != nil {
 		return "", err
 	}
-	return res.md.version, nil
+	return op.result.version, nil
 }
 
 // UpdateRefresh cancels all existing refresh attempts and schedules new
 // attempts with the provided config.
 func (i *Instance) UpdateRefresh(cfg RefreshCfg) {
-	i.resultGuard.Lock()
-	defer i.resultGuard.Unlock()
+	i.refreshLock.Lock()
+	defer i.refreshLock.Unlock()
 	// Cancel any pending refreshes
 	i.cur.cancel()
 	i.next.cancel()
@@ -263,34 +261,34 @@ func (i *Instance) UpdateRefresh(cfg RefreshCfg) {
 // ForceRefresh triggers an immediate refresh operation to be scheduled and
 // used for future connection attempts.
 func (i *Instance) ForceRefresh() {
-	i.resultGuard.Lock()
-	defer i.resultGuard.Unlock()
+	i.refreshLock.Lock()
+	defer i.refreshLock.Unlock()
 	// If the next refresh hasn't started yet, we can cancel it and start
 	// an immediate one
 	if i.next.cancel() {
 		i.next = i.scheduleRefresh(0)
 	}
-	// block all sequential connection attempts on the next refresh result
+	// block all sequential connection attempts on the next refresh operation
 	i.cur = i.next
 }
 
-// result returns the most recent refresh result (waiting for it to complete if
-// necessary)
-func (i *Instance) result(ctx context.Context) (*refreshOperation, error) {
-	i.resultGuard.RLock()
-	res := i.cur
-	i.resultGuard.RUnlock()
+// refreshOperation returns the most recent refresh operation
+// waiting for it to complete if necessary
+func (i *Instance) refreshOperation(ctx context.Context) (*refreshOperation, error) {
+	i.refreshLock.RLock()
+	cur := i.cur
+	i.refreshLock.RUnlock()
 	var err error
 	select {
-	case <-res.ready:
-		err = res.err
+	case <-cur.ready:
+		err = cur.err
 	case <-ctx.Done():
 		err = ctx.Err()
 	}
 	if err != nil {
 		return nil, err
 	}
-	return res, nil
+	return cur, nil
 }
 
 // refreshDuration returns the duration to wait before starting the next
@@ -312,7 +310,7 @@ func refreshDuration(now, certExpiry time.Time) time.Duration {
 
 // scheduleRefresh schedules a refresh operation to be triggered after a given
 // duration. The returned refreshOperation can be used to either Cancel or Wait
-// for the operation's result.
+// for the operation's completion.
 func (i *Instance) scheduleRefresh(d time.Duration) *refreshOperation {
 	r := &refreshOperation{}
 	r.ready = make(chan struct{})
@@ -330,7 +328,7 @@ func (i *Instance) scheduleRefresh(d time.Duration) *refreshOperation {
 				nil,
 			)
 		} else {
-			r.md, r.tlsCfg, r.expiry, r.err = i.r.performRefresh(
+			r.result, r.err = i.r.performRefresh(
 				ctx, i.ConnName, i.key, i.RefreshCfg.UseIAMAuthN)
 		}
 
@@ -344,17 +342,17 @@ func (i *Instance) scheduleRefresh(d time.Duration) *refreshOperation {
 		}
 
 		// Once the refresh is complete, update "current" with working
-		// result and schedule a new refresh
-		i.resultGuard.Lock()
-		defer i.resultGuard.Unlock()
+		// refreshOperation and schedule a new refresh
+		i.refreshLock.Lock()
+		defer i.refreshLock.Unlock()
 
 		// if failed, scheduled the next refresh immediately
 		if r.err != nil {
 			i.next = i.scheduleRefresh(0)
-			// If the latest result is bad, avoid replacing the
-			// used result while it's still valid and potentially
+			// If the latest refreshOperation is bad, avoid replacing the
+			// used refreshOperation while it's still valid and potentially
 			// able to provide successful connections. TODO: This
-			// means that errors while the current result is still
+			// means that errors while the current refreshOperation is still
 			// valid are suppressed. We should try to surface
 			// errors in a more meaningful way.
 			if !i.cur.isValid() {
@@ -366,7 +364,7 @@ func (i *Instance) scheduleRefresh(d time.Duration) *refreshOperation {
 		// Update the current results, and schedule the next refresh in
 		// the future
 		i.cur = r
-		t := refreshDuration(time.Now(), i.cur.expiry)
+		t := refreshDuration(time.Now(), i.cur.result.expiry)
 		i.next = i.scheduleRefresh(t)
 	})
 	return r

--- a/internal/cloudsql/instance.go
+++ b/internal/cloudsql/instance.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	// the refresh buffer is the amount of time before a refresh cycle's
+	// the refresh buffer is the amount of time before a refresh operation's
 	// certificate expires that a new refresh operation begins.
 	refreshBuffer = 4 * time.Minute
 

--- a/internal/cloudsql/instance_test.go
+++ b/internal/cloudsql/instance_test.go
@@ -318,16 +318,16 @@ func TestContextCancelled(t *testing.T) {
 	i.Close()
 
 	// grab the current value of next before scheduling another refresh
-	i.resultGuard.Lock()
+	i.refreshLock.Lock()
 	next := i.next
-	i.resultGuard.Unlock()
+	i.refreshLock.Unlock()
 
 	op := i.scheduleRefresh(time.Nanosecond)
 	<-op.ready
 
-	i.resultGuard.Lock()
+	i.refreshLock.Lock()
 	otherNext := i.next
-	i.resultGuard.Unlock()
+	i.refreshLock.Unlock()
 
 	// if scheduleRefresh returns without scheduling another one,
 	// i.next should be untouched and remain the same pointer value

--- a/internal/cloudsql/refresh.go
+++ b/internal/cloudsql/refresh.go
@@ -277,7 +277,7 @@ func newRefresher(
 	}
 }
 
-// refreshResult contains all the resulting data from the refresh cycle.
+// refreshResult contains all the resulting data from the refresh operation.
 type refreshResult struct {
 	ipAddrs      map[string]string
 	serverCaCert *x509.Certificate


### PR DESCRIPTION
This change brings the Go Connector inline with a recent change in the AlloyDB fork.

In addition, this commit standardizes on "refresh operation" and "refresh result."