### PR TITLE
chore: ensure mock server is initialized correctly

### DIFF
--- a/internal/cloudsql/refresh_test.go
+++ b/internal/cloudsql/refresh_test.go
@@ -220,7 +220,7 @@ func TestRefreshWithIAMAuthErrors(t *testing.T) {
 	inst := mock.NewFakeCSQLInstance("my-project", "my-region", "my-instance")
 	client, cleanup, err := mock.NewSQLAdminService(
 		context.Background(),
-		mock.InstanceGetSuccess(inst, 1),
+		mock.InstanceGetSuccess(inst, 2),
 	)
 	if err != nil {
 		t.Fatalf("failed to create test SQL admin service: %s", err)


### PR DESCRIPTION
The test depends on two calls, not one. When only one was registered this test would sometimes fail.

Fixes #530.