### PR TITLE
chore: remove flaky assertion

### DIFF
--- a/dialer_test.go
+++ b/dialer_test.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"net"
 	"os"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -553,17 +552,5 @@ func TestDialerRemovesInvalidInstancesFromCache(t *testing.T) {
 	d.lock.RUnlock()
 	if ok {
 		t.Fatal("bad instance was not removed from the cache")
-	}
-
-	// Now force the scheduler to run any pending goroutines to ensure the
-	// background refresh is closed.
-	runtime.Gosched()
-
-	// Confirm the background refresh is not running by inspecting
-	// all the running goroutines.
-	buf := make([]byte, 1<<16)
-	runtime.Stack(buf, true)
-	if strings.Contains(string(buf), "scheduleRefresh") {
-		t.Fatal("performRefresh should not be running")
 	}
 }


### PR DESCRIPTION
When run with the -race flag, this test reliably fails without a call to close the instance, and reliably passes when the call is in place. However, without the -race flag, the test will not always pass reliably.

This commit takes a pragmatic approach and reduces test coverage slightly in favor of a stable test build.