### PR TITLE
feat: add support for PSC connections

### DIFF
--- a/internal/cloudsql/refresh.go
+++ b/internal/cloudsql/refresh.go
@@ -87,8 +87,8 @@ func fetchMetadata(ctx context.Context, client *sqladmin.Service, inst ConnName)
 	// resolve DnsName into IP address for PSC
 	if db.DnsName != "" {
 		ipAddrs[PSC] = db.DnsName
-		fmt.Printf("Found DNS NAME!")
 	}
+
 	if len(ipAddrs) == 0 {
 		return metadata{}, errtype.NewConfigError(
 			"cannot connect to instance - it has no supported IP addresses",

--- a/internal/cloudsql/refresh.go
+++ b/internal/cloudsql/refresh.go
@@ -35,6 +35,8 @@ const (
 	PublicIP = "PUBLIC"
 	// PrivateIP is the value for private IP Cloud SQL instances.
 	PrivateIP = "PRIVATE"
+	// PSC is the value for private service connect Cloud SQL instances.
+	PSC = "PSC"
 	// AutoIP selects public IP if available and otherwise selects private
 	// IP.
 	AutoIP = "AutoIP"
@@ -80,6 +82,12 @@ func fetchMetadata(ctx context.Context, client *sqladmin.Service, inst ConnName)
 		case "PRIVATE":
 			ipAddrs[PrivateIP] = ip.IpAddress
 		}
+	}
+
+	// resolve DnsName into IP address for PSC
+	if db.DnsName != "" {
+		ipAddrs[PSC] = db.DnsName
+		fmt.Printf("Found DNS NAME!")
 	}
 	if len(ipAddrs) == 0 {
 		return metadata{}, errtype.NewConfigError(

--- a/internal/cloudsql/refresh_test.go
+++ b/internal/cloudsql/refresh_test.go
@@ -35,6 +35,7 @@ const testDialerID = "some-dialer-id"
 func TestRefresh(t *testing.T) {
 	wantPublicIP := "127.0.0.1"
 	wantPrivateIP := "10.0.0.1"
+	wantPSC := "abcde.12345.us-central1.sql.goog"
 	wantExpiry := time.Now().Add(time.Hour).UTC().Round(time.Second)
 	wantConnName := "my-project:my-region:my-instance"
 	cn, err := ParseConnName(wantConnName)
@@ -45,6 +46,7 @@ func TestRefresh(t *testing.T) {
 		"my-project", "my-region", "my-instance",
 		mock.WithPublicIP(wantPublicIP),
 		mock.WithPrivateIP(wantPrivateIP),
+		mock.WithPSC(wantPSC),
 		mock.WithCertExpiry(wantExpiry),
 	)
 	client, cleanup, err := mock.NewSQLAdminService(
@@ -80,6 +82,13 @@ func TestRefresh(t *testing.T) {
 	}
 	if wantPrivateIP != gotIP {
 		t.Fatalf("metadata IP mismatch, want = %v, got = %v", wantPrivateIP, gotIP)
+	}
+	gotPSC, ok := rr.ipAddrs[PSC]
+	if !ok {
+		t.Fatalf("metadata IP addresses did not include PSC endpoint")
+	}
+	if wantPSC != gotPSC {
+		t.Fatalf("metadata IP mismatch, want = %v. got = %v", wantPSC, gotPSC)
 	}
 	if wantExpiry != rr.expiry {
 		t.Fatalf("expiry mismatch, want = %v, got = %v", wantExpiry, rr.expiry)

--- a/internal/cloudsql/refresh_test.go
+++ b/internal/cloudsql/refresh_test.go
@@ -71,21 +71,21 @@ func TestRefresh(t *testing.T) {
 
 	gotIP, ok := rr.ipAddrs[PublicIP]
 	if !ok {
-		t.Fatalf("metadata IP addresses did not include public address")
+		t.Fatal("metadata IP addresses did not include public address")
 	}
 	if wantPublicIP != gotIP {
 		t.Fatalf("metadata IP mismatch, want = %v, got = %v", wantPublicIP, gotIP)
 	}
 	gotIP, ok = rr.ipAddrs[PrivateIP]
 	if !ok {
-		t.Fatalf("metadata IP addresses did not include private address")
+		t.Fatal("metadata IP addresses did not include private address")
 	}
 	if wantPrivateIP != gotIP {
 		t.Fatalf("metadata IP mismatch, want = %v, got = %v", wantPrivateIP, gotIP)
 	}
 	gotPSC, ok := rr.ipAddrs[PSC]
 	if !ok {
-		t.Fatalf("metadata IP addresses did not include PSC endpoint")
+		t.Fatal("metadata IP addresses did not include PSC endpoint")
 	}
 	if wantPSC != gotPSC {
 		t.Fatalf("metadata IP mismatch, want = %v. got = %v", wantPSC, gotPSC)

--- a/internal/mock/cloudsql.go
+++ b/internal/mock/cloudsql.go
@@ -50,6 +50,7 @@ type FakeCSQLInstance struct {
 	// ipAddrs is a map of IP type (PUBLIC or PRIVATE) to IP address.
 	ipAddrs      map[string]string
 	backendType  string
+	DNSName      string
 	signer       SignFunc
 	clientSigner ClientSignFunc
 	Key          *rsa.PrivateKey
@@ -78,6 +79,13 @@ func WithPublicIP(addr string) FakeCSQLInstanceOption {
 func WithPrivateIP(addr string) FakeCSQLInstanceOption {
 	return func(f *FakeCSQLInstance) {
 		f.ipAddrs["PRIVATE"] = addr
+	}
+}
+
+// WithPSC sets the PSC DnsName to addr.
+func WithPSC(dns string) FakeCSQLInstanceOption {
+	return func(f *FakeCSQLInstance) {
+		f.DNSName = dns
 	}
 }
 
@@ -155,6 +163,7 @@ func NewFakeCSQLInstance(project, region, name string, opts ...FakeCSQLInstanceO
 		region:       region,
 		name:         name,
 		ipAddrs:      map[string]string{"PUBLIC": "0.0.0.0"},
+		DNSName:      "",
 		dbVersion:    "POSTGRES_12", // default of no particular importance
 		backendType:  "SECOND_GEN",
 		signer:       SelfSign,

--- a/internal/mock/sqladmin.go
+++ b/internal/mock/sqladmin.go
@@ -119,6 +119,7 @@ func InstanceGetSuccess(i FakeCSQLInstance, ct int) *Request {
 	db := &sqladmin.ConnectSettings{
 		BackendType:     i.backendType,
 		DatabaseVersion: i.dbVersion,
+		DnsName:         i.DNSName,
 		IpAddresses:     ips,
 		Region:          i.region,
 		ServerCaCert:    &sqladmin.SslCert{Cert: string(certBytes)},

--- a/options.go
+++ b/options.go
@@ -258,6 +258,13 @@ func WithPrivateIP() DialOption {
 	}
 }
 
+// WithPSC returns a DialOption that specifies a PSC endpoint will be used to connect.
+func WithPSC() DialOption {
+	return func(cfg *dialCfg) {
+		cfg.ipType = cloudsql.PSC
+	}
+}
+
 // WithAutoIP returns a DialOption that selects the public IP if available and
 // otherwise falls back to private IP. This option is present for backwards
 // compatibility only and is not recommended for use in production.


### PR DESCRIPTION
Add a new dialOption for `WithPSC()` to support connections to Cloud SQL using [private service connect](https://cloud.google.com/vpc/docs/private-service-connect).