### PR TITLE
fix: re-use existing connection info on force refresh

### DIFF
--- a/internal/cloudsql/instance.go
+++ b/internal/cloudsql/instance.go
@@ -259,17 +259,16 @@ func (i *Instance) UpdateRefresh(cfg RefreshCfg) {
 }
 
 // ForceRefresh triggers an immediate refresh operation to be scheduled and
-// used for future connection attempts.
+// used for future connection attempts. Until the refresh completes, the
+// existing connection info will be available for use.
 func (i *Instance) ForceRefresh() {
 	i.refreshLock.Lock()
 	defer i.refreshLock.Unlock()
-	// If the next refresh hasn't started yet, we can cancel it and start
-	// an immediate one
+	// If the next refresh hasn't started yet, we can cancel it and start an
+	// immediate one
 	if i.next.cancel() {
 		i.next = i.scheduleRefresh(0)
 	}
-	// block all sequential connection attempts on the next refresh operation
-	i.cur = i.next
 }
 
 // refreshOperation returns the most recent refresh operation


### PR DESCRIPTION
Rather than immediately discard the current connection info, this commit keeps the current info available in case temporary network issues have caused the failure. When the refresh operation completes, it will update the connection info with a refreshed value.