### PR TITLE
chore: check for latest Go version in govulncheck

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -32,5 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Run govulncheck
     steps:
+      - name: Setup Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: "1.21"
+          check-latest: true
       - id: govulncheck
         uses: golang/govulncheck-action@dd3ead030e4f2cf713062f7a3395191802364e13 # v1


### PR DESCRIPTION
Look at cached version of Golang and if newer version is available, use it.