### PR TITLE
chore: add label to dependency dashboard in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "config:recommended"
   ],
+  "dependencyDashboardLabels": ["type: process"],
   "commitMessagePrefix": "deps: ",
   "postUpdateOptions": [
     "gomodTidy"


### PR DESCRIPTION
Fixes #644