### PR TITLE
chore: move all cloudsql.Instance references behind methods

### DIFF
--- a/dialer_test.go
+++ b/dialer_test.go
@@ -185,7 +185,7 @@ func TestIAMAuthn(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewDialer failed with error = %v", err)
 			}
-			if gotIAMAuthN := d.defaultDialCfg.refreshCfg.UseIAMAuthN; gotIAMAuthN != tc.wantIAMAuthN {
+			if gotIAMAuthN := d.defaultDialConfig.refreshConfig.UseIAMAuthN; gotIAMAuthN != tc.wantIAMAuthN {
 				t.Fatalf("want = %v, got = %v", tc.wantIAMAuthN, gotIAMAuthN)
 			}
 		})

--- a/internal/cloudsql/instance_test.go
+++ b/internal/cloudsql/instance_test.go
@@ -95,7 +95,7 @@ func TestInstanceEngineVersion(t *testing.T) {
 				t.Fatalf("%v", err)
 			}
 		}()
-		i := NewInstance(testInstanceConnName(), client, RSAKey, 30*time.Second, nil, "", RefreshCfg{})
+		i := NewInstance(testInstanceConnName(), client, RSAKey, 30*time.Second, nil, "", RefreshConfig{})
 		if err != nil {
 			t.Fatalf("failed to init instance: %v", err)
 		}
@@ -129,7 +129,7 @@ func TestConnectInfo(t *testing.T) {
 		}
 	}()
 
-	i := NewInstance(testInstanceConnName(), client, RSAKey, 30*time.Second, nil, "", RefreshCfg{})
+	i := NewInstance(testInstanceConnName(), client, RSAKey, 30*time.Second, nil, "", RefreshConfig{})
 
 	gotAddr, gotTLSCfg, err := i.ConnectInfo(ctx, PublicIP)
 	if err != nil {
@@ -194,7 +194,7 @@ func TestConnectInfoAutoIP(t *testing.T) {
 			}
 		}()
 
-		i := NewInstance(testInstanceConnName(), client, RSAKey, 30*time.Second, nil, "", RefreshCfg{})
+		i := NewInstance(testInstanceConnName(), client, RSAKey, 30*time.Second, nil, "", RefreshConfig{})
 		if err != nil {
 			t.Fatalf("failed to create mock instance: %v", err)
 		}
@@ -223,7 +223,7 @@ func TestConnectInfoErrors(t *testing.T) {
 	defer cleanup()
 
 	// Use a timeout that should fail instantly
-	i := NewInstance(testInstanceConnName(), client, RSAKey, 0, nil, "", RefreshCfg{})
+	i := NewInstance(testInstanceConnName(), client, RSAKey, 0, nil, "", RefreshConfig{})
 
 	_, _, err = i.ConnectInfo(ctx, PublicIP)
 	var wantErr *errtype.DialError
@@ -248,7 +248,7 @@ func TestClose(t *testing.T) {
 	defer cleanup()
 
 	// Set up an instance and then close it immediately
-	i := NewInstance(testInstanceConnName(), client, RSAKey, 30, nil, "", RefreshCfg{})
+	i := NewInstance(testInstanceConnName(), client, RSAKey, 30, nil, "", RefreshConfig{})
 	i.Close()
 
 	_, _, err = i.ConnectInfo(ctx, PublicIP)
@@ -311,7 +311,7 @@ func TestContextCancelled(t *testing.T) {
 	defer cleanup()
 
 	// Set up an instance and then close it immediately
-	i := NewInstance(testInstanceConnName(), client, RSAKey, 30, nil, "", RefreshCfg{})
+	i := NewInstance(testInstanceConnName(), client, RSAKey, 30, nil, "", RefreshConfig{})
 	if err != nil {
 		t.Fatalf("failed to initialize Instance: %v", err)
 	}

--- a/options.go
+++ b/options.go
@@ -210,18 +210,18 @@ func WithIAMAuthN() Option {
 }
 
 // A DialOption is an option for configuring how a Dialer's Dial call is executed.
-type DialOption func(d *dialCfg)
+type DialOption func(d *dialConfig)
 
-type dialCfg struct {
-	dialFunc     func(ctx context.Context, network, addr string) (net.Conn, error)
-	ipType       string
-	tcpKeepAlive time.Duration
-	refreshCfg   cloudsql.RefreshCfg
+type dialConfig struct {
+	dialFunc      func(ctx context.Context, network, addr string) (net.Conn, error)
+	ipType        string
+	tcpKeepAlive  time.Duration
+	refreshConfig cloudsql.RefreshConfig
 }
 
 // DialOptions turns a list of DialOption instances into an DialOption.
 func DialOptions(opts ...DialOption) DialOption {
-	return func(cfg *dialCfg) {
+	return func(cfg *dialConfig) {
 		for _, opt := range opts {
 			opt(cfg)
 		}
@@ -232,35 +232,35 @@ func DialOptions(opts ...DialOption) DialOption {
 // individual call to Dial. To configure a dial function across all invocations
 // of Dial, use WithDialFunc.
 func WithOneOffDialFunc(dial func(ctx context.Context, network, addr string) (net.Conn, error)) DialOption {
-	return func(c *dialCfg) {
+	return func(c *dialConfig) {
 		c.dialFunc = dial
 	}
 }
 
 // WithTCPKeepAlive returns a DialOption that specifies the tcp keep alive period for the connection returned by Dial.
 func WithTCPKeepAlive(d time.Duration) DialOption {
-	return func(cfg *dialCfg) {
+	return func(cfg *dialConfig) {
 		cfg.tcpKeepAlive = d
 	}
 }
 
 // WithPublicIP returns a DialOption that specifies a public IP will be used to connect.
 func WithPublicIP() DialOption {
-	return func(cfg *dialCfg) {
+	return func(cfg *dialConfig) {
 		cfg.ipType = cloudsql.PublicIP
 	}
 }
 
 // WithPrivateIP returns a DialOption that specifies a private IP (VPC) will be used to connect.
 func WithPrivateIP() DialOption {
-	return func(cfg *dialCfg) {
+	return func(cfg *dialConfig) {
 		cfg.ipType = cloudsql.PrivateIP
 	}
 }
 
 // WithPSC returns a DialOption that specifies a PSC endpoint will be used to connect.
 func WithPSC() DialOption {
-	return func(cfg *dialCfg) {
+	return func(cfg *dialConfig) {
 		cfg.ipType = cloudsql.PSC
 	}
 }
@@ -269,7 +269,7 @@ func WithPSC() DialOption {
 // otherwise falls back to private IP. This option is present for backwards
 // compatibility only and is not recommended for use in production.
 func WithAutoIP() DialOption {
-	return func(cfg *dialCfg) {
+	return func(cfg *dialConfig) {
 		cfg.ipType = cloudsql.AutoIP
 	}
 }
@@ -282,7 +282,7 @@ func WithAutoIP() DialOption {
 // Toggling this option on or off between Dials may cause increased API usage
 // and/or delayed connection attempts.
 func WithDialIAMAuthN(b bool) DialOption {
-	return func(cfg *dialCfg) {
-		cfg.refreshCfg.UseIAMAuthN = b
+	return func(cfg *dialConfig) {
+		cfg.refreshConfig.UseIAMAuthN = b
 	}
 }


### PR DESCRIPTION
This is the first step to extracting an interface for cloudsql.Instance.

Also, prefer full words (cfg vs config) for types, field names, and compound variable names.