### PR TITLE
chore: flatten refresh config into bool

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -343,12 +343,12 @@ func (d *Dialer) instance(cn cloudsql.ConnName, useIAMAuthN *bool) *cloudsql.Ins
 		// Recheck to ensure instance wasn't created or changed between locks
 		i, ok = d.instances[cn]
 		if !ok {
-			var enable bool
+			var useIAMAuthNDial bool
 			if useIAMAuthN != nil {
-				enable = *useIAMAuthN
+				useIAMAuthNDial = *useIAMAuthN
 			}
 			i = cloudsql.NewInstance(cn, d.sqladmin, d.key,
-				d.refreshTimeout, d.iamTokenSource, d.dialerID, enable)
+				d.refreshTimeout, d.iamTokenSource, d.dialerID, useIAMAuthNDial)
 			d.instances[cn] = i
 		} else if useIAMAuthN != nil && *useIAMAuthN != i.UseIAMAuthNDial() {
 			// Update the instance with the new refresh config

--- a/dialer.go
+++ b/dialer.go
@@ -160,9 +160,7 @@ func NewDialer(ctx context.Context, opts ...Option) (*Dialer, error) {
 	dc := dialConfig{
 		ipType:       cloudsql.PublicIP,
 		tcpKeepAlive: defaultTCPKeepAlive,
-		refreshConfig: cloudsql.RefreshConfig{
-			UseIAMAuthN: cfg.useIAMAuthN,
-		},
+		useIAMAuthN:  cfg.useIAMAuthN,
 	}
 	for _, opt := range cfg.dialOpts {
 		opt(&dc)
@@ -209,7 +207,7 @@ func (d *Dialer) Dial(ctx context.Context, instance string, opts ...DialOption) 
 
 	var endInfo trace.EndSpanFunc
 	ctx, endInfo = trace.StartSpan(ctx, "cloud.google.com/go/cloudsqlconn/internal.InstanceInfo")
-	i := d.instance(cn, &cfg.refreshConfig)
+	i := d.instance(cn, &cfg.useIAMAuthN)
 	addr, tlsConfig, err := i.ConnectInfo(ctx, cfg.ipType)
 	if err != nil {
 		d.removeInstance(i)
@@ -289,7 +287,7 @@ func (d *Dialer) Warmup(_ context.Context, instance string, opts ...DialOption) 
 	for _, opt := range opts {
 		opt(&cfg)
 	}
-	_ = d.instance(cn, &cfg.refreshConfig)
+	_ = d.instance(cn, &cfg.useIAMAuthN)
 	return nil
 }
 
@@ -334,27 +332,27 @@ func (d *Dialer) Close() error {
 
 // instance is a helper function for returning the appropriate instance object in a threadsafe way.
 // It will create a new instance object, modify the existing one, or leave it unchanged as needed.
-func (d *Dialer) instance(cn cloudsql.ConnName, r *cloudsql.RefreshConfig) *cloudsql.Instance {
+func (d *Dialer) instance(cn cloudsql.ConnName, useIAMAuthN *bool) *cloudsql.Instance {
 	// Check instance cache
 	d.lock.RLock()
 	i, ok := d.instances[cn]
 	d.lock.RUnlock()
 	// If the instance hasn't been created yet or if the refreshConfig has changed
-	if !ok || (r != nil && *r != i.RefreshConfig()) {
+	if !ok || (useIAMAuthN != nil && *useIAMAuthN != i.UseIAMAuthNDial()) {
 		d.lock.Lock()
 		// Recheck to ensure instance wasn't created or changed between locks
 		i, ok = d.instances[cn]
 		if !ok {
-			// Create a new instance
-			if r == nil {
-				r = &d.defaultDialConfig.refreshConfig
+			var enable bool
+			if useIAMAuthN != nil {
+				enable = *useIAMAuthN
 			}
 			i = cloudsql.NewInstance(cn, d.sqladmin, d.key,
-				d.refreshTimeout, d.iamTokenSource, d.dialerID, *r)
+				d.refreshTimeout, d.iamTokenSource, d.dialerID, enable)
 			d.instances[cn] = i
-		} else if r != nil && *r != i.RefreshConfig() {
+		} else if useIAMAuthN != nil && *useIAMAuthN != i.UseIAMAuthNDial() {
 			// Update the instance with the new refresh config
-			i.UpdateRefresh(*r)
+			i.UpdateRefresh(*useIAMAuthN)
 		}
 		d.lock.Unlock()
 	}

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -185,7 +185,7 @@ func TestIAMAuthn(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewDialer failed with error = %v", err)
 			}
-			if gotIAMAuthN := d.defaultDialConfig.refreshConfig.UseIAMAuthN; gotIAMAuthN != tc.wantIAMAuthN {
+			if gotIAMAuthN := d.defaultDialConfig.useIAMAuthN; gotIAMAuthN != tc.wantIAMAuthN {
 				t.Fatalf("want = %v, got = %v", tc.wantIAMAuthN, gotIAMAuthN)
 			}
 		})

--- a/internal/cloudsql/instance.go
+++ b/internal/cloudsql/instance.go
@@ -120,11 +120,6 @@ func (r *refreshOperation) isValid() bool {
 	}
 }
 
-// RefreshConfig is a collection of attributes that trigger new refresh operations.
-type RefreshConfig struct {
-	UseIAMAuthN bool
-}
-
 // Instance manages the information used to connect to the Cloud SQL instance
 // by periodically calling the Cloud SQL Admin API. It automatically refreshes
 // the required information approximately 4 minutes before the previous
@@ -143,8 +138,8 @@ type Instance struct {
 	l *rate.Limiter
 	r refresher
 
-	refreshLock   sync.RWMutex
-	refreshConfig RefreshConfig
+	mu              sync.RWMutex
+	useIAMAuthNDial bool
 	// cur represents the current refreshOperation that will be used to
 	// create connections. If a valid complete refreshOperation isn't
 	// available it's possible for cur to be equal to next.
@@ -167,7 +162,7 @@ func NewInstance(
 	refreshTimeout time.Duration,
 	ts oauth2.TokenSource,
 	dialerID string,
-	r RefreshConfig,
+	useIAMAuthNDial bool,
 ) *Instance {
 	ctx, cancel := context.WithCancel(context.Background())
 	i := &Instance{
@@ -179,17 +174,17 @@ func NewInstance(
 			ts,
 			dialerID,
 		),
-		refreshTimeout: refreshTimeout,
-		refreshConfig:  r,
-		ctx:            ctx,
-		cancel:         cancel,
+		refreshTimeout:  refreshTimeout,
+		useIAMAuthNDial: useIAMAuthNDial,
+		ctx:             ctx,
+		cancel:          cancel,
 	}
 	// For the initial refresh operation, set cur = next so that connection
 	// requests block until the first refresh is complete.
-	i.refreshLock.Lock()
+	i.mu.Lock()
 	i.cur = i.scheduleRefresh(0)
 	i.next = i.cur
-	i.refreshLock.Unlock()
+	i.mu.Unlock()
 	return i
 }
 
@@ -204,10 +199,13 @@ func (i *Instance) ConnName() ConnName {
 	return i.connName
 }
 
-// RefreshConfig returns the refresh configuration associated with this
-// instance.
-func (i *Instance) RefreshConfig() RefreshConfig {
-	return i.refreshConfig
+// UseIAMAuthNDial reports whether the instance has set IAM AuthN on a per-dial
+// basis. This field can change from one Dial attemtp to another and affects
+// how the background refresh functions by either inserting an OAuth2 token
+// into the ephemeral certificate request or leaving it blank. It is meant to
+// override the dialer setting.
+func (i *Instance) UseIAMAuthNDial() bool {
+	return i.useIAMAuthNDial
 }
 
 // Close closes the instance; it stops the refresh cycle and prevents it from
@@ -262,14 +260,14 @@ func (i *Instance) InstanceEngineVersion(ctx context.Context) (string, error) {
 
 // UpdateRefresh cancels all existing refresh attempts and schedules new
 // attempts with the provided config.
-func (i *Instance) UpdateRefresh(c RefreshConfig) {
-	i.refreshLock.Lock()
-	defer i.refreshLock.Unlock()
+func (i *Instance) UpdateRefresh(useIAMAuthNDial bool) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
 	// Cancel any pending refreshes
 	i.cur.cancel()
 	i.next.cancel()
 	// update the refresh config as needed
-	i.refreshConfig = c
+	i.useIAMAuthNDial = useIAMAuthNDial
 	// reschedule a new refresh immediately
 	i.cur = i.scheduleRefresh(0)
 	i.next = i.cur
@@ -279,8 +277,8 @@ func (i *Instance) UpdateRefresh(c RefreshConfig) {
 // used for future connection attempts. Until the refresh completes, the
 // existing connection info will be available for use if valid.
 func (i *Instance) ForceRefresh() {
-	i.refreshLock.Lock()
-	defer i.refreshLock.Unlock()
+	i.mu.Lock()
+	defer i.mu.Unlock()
 	// If the next refresh hasn't started yet, we can cancel it and start an
 	// immediate one
 	if i.next.cancel() {
@@ -296,9 +294,9 @@ func (i *Instance) ForceRefresh() {
 // refreshOperation returns the most recent refresh operation
 // waiting for it to complete if necessary
 func (i *Instance) refreshOperation(ctx context.Context) (*refreshOperation, error) {
-	i.refreshLock.RLock()
+	i.mu.RLock()
 	cur := i.cur
-	i.refreshLock.RUnlock()
+	i.mu.RUnlock()
 	var err error
 	select {
 	case <-cur.ready:
@@ -350,7 +348,7 @@ func (i *Instance) scheduleRefresh(d time.Duration) *refreshOperation {
 			)
 		} else {
 			r.result, r.err = i.r.performRefresh(
-				ctx, i.connName, i.key, i.refreshConfig.UseIAMAuthN)
+				ctx, i.connName, i.key, i.useIAMAuthNDial)
 		}
 
 		close(r.ready)
@@ -364,8 +362,8 @@ func (i *Instance) scheduleRefresh(d time.Duration) *refreshOperation {
 
 		// Once the refresh is complete, update "current" with working
 		// refreshOperation and schedule a new refresh
-		i.refreshLock.Lock()
-		defer i.refreshLock.Unlock()
+		i.mu.Lock()
+		defer i.mu.Unlock()
 
 		// if failed, scheduled the next refresh immediately
 		if r.err != nil {

--- a/internal/cloudsql/instance.go
+++ b/internal/cloudsql/instance.go
@@ -200,7 +200,7 @@ func (i *Instance) ConnName() ConnName {
 }
 
 // UseIAMAuthNDial reports whether the instance has set IAM AuthN on a per-dial
-// basis. This field can change from one Dial attemtp to another and affects
+// basis. This field can change from one Dial attempt to another and affects
 // how the background refresh functions by either inserting an OAuth2 token
 // into the ephemeral certificate request or leaving it blank. It is meant to
 // override the dialer setting.

--- a/internal/cloudsql/instance.go
+++ b/internal/cloudsql/instance.go
@@ -266,9 +266,8 @@ func (i *Instance) UpdateRefresh(useIAMAuthNDial bool) {
 	// Cancel any pending refreshes
 	i.cur.cancel()
 	i.next.cancel()
-	// update the refresh config as needed
+
 	i.useIAMAuthNDial = useIAMAuthNDial
-	// reschedule a new refresh immediately
 	i.cur = i.scheduleRefresh(0)
 	i.next = i.cur
 }

--- a/internal/cloudsql/instance_test.go
+++ b/internal/cloudsql/instance_test.go
@@ -95,7 +95,7 @@ func TestInstanceEngineVersion(t *testing.T) {
 				t.Fatalf("%v", err)
 			}
 		}()
-		i := NewInstance(testInstanceConnName(), client, RSAKey, 30*time.Second, nil, "", RefreshConfig{})
+		i := NewInstance(testInstanceConnName(), client, RSAKey, 30*time.Second, nil, "", false)
 		if err != nil {
 			t.Fatalf("failed to init instance: %v", err)
 		}
@@ -129,7 +129,7 @@ func TestConnectInfo(t *testing.T) {
 		}
 	}()
 
-	i := NewInstance(testInstanceConnName(), client, RSAKey, 30*time.Second, nil, "", RefreshConfig{})
+	i := NewInstance(testInstanceConnName(), client, RSAKey, 30*time.Second, nil, "", false)
 
 	gotAddr, gotTLSCfg, err := i.ConnectInfo(ctx, PublicIP)
 	if err != nil {
@@ -194,7 +194,7 @@ func TestConnectInfoAutoIP(t *testing.T) {
 			}
 		}()
 
-		i := NewInstance(testInstanceConnName(), client, RSAKey, 30*time.Second, nil, "", RefreshConfig{})
+		i := NewInstance(testInstanceConnName(), client, RSAKey, 30*time.Second, nil, "", false)
 		if err != nil {
 			t.Fatalf("failed to create mock instance: %v", err)
 		}
@@ -223,7 +223,7 @@ func TestConnectInfoErrors(t *testing.T) {
 	defer cleanup()
 
 	// Use a timeout that should fail instantly
-	i := NewInstance(testInstanceConnName(), client, RSAKey, 0, nil, "", RefreshConfig{})
+	i := NewInstance(testInstanceConnName(), client, RSAKey, 0, nil, "", false)
 
 	_, _, err = i.ConnectInfo(ctx, PublicIP)
 	var wantErr *errtype.DialError
@@ -248,7 +248,7 @@ func TestClose(t *testing.T) {
 	defer cleanup()
 
 	// Set up an instance and then close it immediately
-	i := NewInstance(testInstanceConnName(), client, RSAKey, 30, nil, "", RefreshConfig{})
+	i := NewInstance(testInstanceConnName(), client, RSAKey, 30, nil, "", false)
 	i.Close()
 
 	_, _, err = i.ConnectInfo(ctx, PublicIP)
@@ -311,23 +311,23 @@ func TestContextCancelled(t *testing.T) {
 	defer cleanup()
 
 	// Set up an instance and then close it immediately
-	i := NewInstance(testInstanceConnName(), client, RSAKey, 30, nil, "", RefreshConfig{})
+	i := NewInstance(testInstanceConnName(), client, RSAKey, 30, nil, "", false)
 	if err != nil {
 		t.Fatalf("failed to initialize Instance: %v", err)
 	}
 	i.Close()
 
 	// grab the current value of next before scheduling another refresh
-	i.refreshLock.Lock()
+	i.mu.Lock()
 	next := i.next
-	i.refreshLock.Unlock()
+	i.mu.Unlock()
 
 	op := i.scheduleRefresh(time.Nanosecond)
 	<-op.ready
 
-	i.refreshLock.Lock()
+	i.mu.Lock()
 	otherNext := i.next
-	i.refreshLock.Unlock()
+	i.mu.Unlock()
 
 	// if scheduleRefresh returns without scheduling another one,
 	// i.next should be untouched and remain the same pointer value

--- a/internal/cloudsql/refresh.go
+++ b/internal/cloudsql/refresh.go
@@ -306,7 +306,7 @@ type refresher struct {
 
 // performRefresh immediately performs a full refresh operation using the Cloud
 // SQL Admin API.
-func (r refresher) performRefresh(ctx context.Context, cn ConnName, k *rsa.PrivateKey, iamAuthN bool) (rr refreshResult, err error) {
+func (r refresher) performRefresh(ctx context.Context, cn ConnName, k *rsa.PrivateKey, iamAuthNDial bool) (rr refreshResult, err error) {
 	var refreshEnd trace.EndSpanFunc
 	ctx, refreshEnd = trace.StartSpan(ctx, "cloud.google.com/go/cloudsqlconn/internal.RefreshConnection",
 		trace.AddInstanceName(cn.String()),
@@ -337,7 +337,7 @@ func (r refresher) performRefresh(ctx context.Context, cn ConnName, k *rsa.Priva
 	go func() {
 		defer close(ecC)
 		var iamTS oauth2.TokenSource
-		if iamAuthN {
+		if iamAuthNDial {
 			iamTS = r.ts
 		}
 		ec, err := fetchEphemeralCert(ctx, r.client, cn, k, iamTS)
@@ -355,7 +355,7 @@ func (r refresher) performRefresh(ctx context.Context, cn ConnName, k *rsa.Priva
 	case <-ctx.Done():
 		return rr, fmt.Errorf("refresh failed: %w", ctx.Err())
 	}
-	if iamAuthN {
+	if iamAuthNDial {
 		if vErr := supportsAutoIAMAuthN(md.version); vErr != nil {
 			return refreshResult{}, vErr
 		}

--- a/options.go
+++ b/options.go
@@ -213,10 +213,10 @@ func WithIAMAuthN() Option {
 type DialOption func(d *dialConfig)
 
 type dialConfig struct {
-	dialFunc      func(ctx context.Context, network, addr string) (net.Conn, error)
-	ipType        string
-	tcpKeepAlive  time.Duration
-	refreshConfig cloudsql.RefreshConfig
+	dialFunc     func(ctx context.Context, network, addr string) (net.Conn, error)
+	ipType       string
+	tcpKeepAlive time.Duration
+	useIAMAuthN  bool
 }
 
 // DialOptions turns a list of DialOption instances into an DialOption.
@@ -283,6 +283,6 @@ func WithAutoIP() DialOption {
 // and/or delayed connection attempts.
 func WithDialIAMAuthN(b bool) DialOption {
 	return func(cfg *dialConfig) {
-		cfg.refreshConfig.UseIAMAuthN = b
+		cfg.useIAMAuthN = b
 	}
 }


### PR DESCRIPTION
The only value that will ever affect a refresh is Auto IAM AuthN. This commit removes the unnecessary struct wrapper in favor of a simple bool or bool pointer.