### PR TITLE
fix: ensure cert refresh recovers from sleep

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -295,6 +295,15 @@ func (d *Dialer) Dial(ctx context.Context, instance string, opts ...DialOption) 
 }
 
 func invalidClientCert(c *tls.Config) bool {
+	// The following conditions should be impossible (no certs, nil leaf), but
+	// just in case there's an unknown edge case, check assumptions before
+	// proceeding.
+	if len(c.Certificates) == 0 {
+		return true
+	}
+	if c.Certificates[0].Leaf == nil {
+		return true
+	}
 	return time.Now().After(c.Certificates[0].Leaf.NotAfter)
 }
 


### PR DESCRIPTION
When a computer wakes from sleep after more than ~1 hour and a client tries to connect, the internal certificate cache will have an expired certificate. In the past, we erroneously believed that the TLS handshake would fail if the client certificate expired. However, with TLS 1.3, the client is the last to send a handshake message, and so the server is unable to report any errors until the first client read. See https://go.dev/doc/go1.12#tls_1_3.

As a result, clients who tried to connect after sleep would see bad certificate errors which would resolve only once the remaining refresh duration expired (sleep time + remaining duration).

This commit adds code to check if the client certificate is expired and immediately triggers a blocking refresh if it is. This means that in the case where a cached certificate has expired, it will be discarded and a new one will be retrieved before continuing with the connection.

Related to https://github.com/GoogleCloudPlatform/cloud-sql-proxy/issues/1788