### PR TITLE
feat: add support for debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ As OpenTelemetry has now reached feature parity with OpenCensus, the migration
 from OpenCensus to OpenTelemetry is strongly encouraged.
 [OpenTelemetry bridge](https://github.com/open-telemetry/opentelemetry-go/tree/main/bridge/opencensus)
 can be leveraged to migrate to OpenTelemetry without the need of replacing the
-OpenCensus APIs in this library. Example code is shown below for migrating an 
+OpenCensus APIs in this library. Example code is shown below for migrating an
 application using the OpenTelemetry bridge for traces.
 
 ```golang
@@ -427,6 +427,39 @@ It shouldn't impact database operations.
 [exporter]: https://opencensus.io/exporters/
 [Cloud Monitoring]: https://cloud.google.com/monitoring
 [Cloud Trace]: https://cloud.google.com/trace
+
+### Debug Logging
+
+The Go Connector supports optional debug logging to help diagnose problems with
+the background certificate refresh. To enable it, provide a logger that
+implements the `debug.Logger` interface when initializing the Dialer.
+
+For example:
+
+``` go
+import (
+    "context"
+    "net"
+
+    "cloud.google.com/go/cloudsqlconn"
+)
+
+type myLogger struct{}
+
+func (l *myLogger) Debugf(format string, args ...interface{}) {
+    // Log as you like here
+}
+
+func connect() {
+    l := &myLogger{}
+
+    d, err := NewDialer(
+        context.Background(),
+        cloudsqlconn.WithDebugLogger(l),
+    )
+    // use dialer as usual...
+}
+```
 
 ## Support policy
 

--- a/debug/debug.go
+++ b/debug/debug.go
@@ -1,0 +1,21 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debug
+
+// Logger is the interface used for debug logging. By default, it is unused.
+type Logger interface {
+	// Debugf is for reporting information about internal operations.
+	Debugf(format string, args ...interface{})
+}

--- a/internal/cloudsql/instance_test.go
+++ b/internal/cloudsql/instance_test.go
@@ -27,6 +27,10 @@ import (
 	"cloud.google.com/go/cloudsqlconn/internal/mock"
 )
 
+type nullLogger struct{}
+
+func (nullLogger) Debugf(string, ...interface{}) {}
+
 // genRSAKey generates an RSA key used for test.
 func genRSAKey() *rsa.PrivateKey {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -65,7 +69,10 @@ func TestInstanceEngineVersion(t *testing.T) {
 				t.Fatalf("%v", err)
 			}
 		}()
-		i := NewInstance(testInstanceConnName(), client, RSAKey, 30*time.Second, nil, "", false)
+		i := NewInstance(
+			testInstanceConnName(), nullLogger{}, client,
+			RSAKey, 30*time.Second, nil, "", false,
+		)
 		if err != nil {
 			t.Fatalf("failed to init instance: %v", err)
 		}
@@ -99,7 +106,10 @@ func TestConnectInfo(t *testing.T) {
 		}
 	}()
 
-	i := NewInstance(testInstanceConnName(), client, RSAKey, 30*time.Second, nil, "", false)
+	i := NewInstance(
+		testInstanceConnName(), nullLogger{}, client,
+		RSAKey, 30*time.Second, nil, "", false,
+	)
 
 	gotAddr, gotTLSCfg, err := i.ConnectInfo(ctx, PublicIP)
 	if err != nil {
@@ -164,7 +174,10 @@ func TestConnectInfoAutoIP(t *testing.T) {
 			}
 		}()
 
-		i := NewInstance(testInstanceConnName(), client, RSAKey, 30*time.Second, nil, "", false)
+		i := NewInstance(
+			testInstanceConnName(), nullLogger{}, client,
+			RSAKey, 30*time.Second, nil, "", false,
+		)
 		if err != nil {
 			t.Fatalf("failed to create mock instance: %v", err)
 		}
@@ -193,7 +206,10 @@ func TestConnectInfoErrors(t *testing.T) {
 	defer cleanup()
 
 	// Use a timeout that should fail instantly
-	i := NewInstance(testInstanceConnName(), client, RSAKey, 0, nil, "", false)
+	i := NewInstance(
+		testInstanceConnName(), nullLogger{}, client,
+		RSAKey, 0, nil, "", false,
+	)
 
 	_, _, err = i.ConnectInfo(ctx, PublicIP)
 	var wantErr *errtype.DialError
@@ -218,7 +234,10 @@ func TestClose(t *testing.T) {
 	defer cleanup()
 
 	// Set up an instance and then close it immediately
-	i := NewInstance(testInstanceConnName(), client, RSAKey, 30, nil, "", false)
+	i := NewInstance(
+		testInstanceConnName(), nullLogger{}, client,
+		RSAKey, 30*time.Second, nil, "", false,
+	)
 	i.Close()
 
 	_, _, err = i.ConnectInfo(ctx, PublicIP)
@@ -281,7 +300,10 @@ func TestContextCancelled(t *testing.T) {
 	defer cleanup()
 
 	// Set up an instance and then close it immediately
-	i := NewInstance(testInstanceConnName(), client, RSAKey, 30, nil, "", false)
+	i := NewInstance(
+		testInstanceConnName(), nullLogger{}, client,
+		RSAKey, 30*time.Second, nil, "", false,
+	)
 	if err != nil {
 		t.Fatalf("failed to initialize Instance: %v", err)
 	}

--- a/internal/cloudsql/refresh.go
+++ b/internal/cloudsql/refresh.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"cloud.google.com/go/cloudsqlconn/debug"
 	"cloud.google.com/go/cloudsqlconn/errtype"
 	"cloud.google.com/go/cloudsqlconn/instance"
 	"cloud.google.com/go/cloudsqlconn/internal/trace"
@@ -283,12 +284,14 @@ func genVerifyPeerCertificateFunc(cn instance.ConnName, pool *x509.CertPool) fun
 
 // newRefresher creates a Refresher.
 func newRefresher(
+	l debug.Logger,
 	svc *sqladmin.Service,
 	ts oauth2.TokenSource,
 	dialerID string,
 ) refresher {
 	return refresher{
 		dialerID: dialerID,
+		logger:   l,
 		client:   svc,
 		ts:       ts,
 	}
@@ -308,6 +311,7 @@ type refreshResult struct {
 type refresher struct {
 	// dialerID is the unique ID of the associated dialer.
 	dialerID string
+	logger   debug.Logger
 	client   *sqladmin.Service
 	// ts is the TokenSource used for IAM DB AuthN.
 	ts oauth2.TokenSource

--- a/internal/cloudsql/refresh_test.go
+++ b/internal/cloudsql/refresh_test.go
@@ -60,7 +60,7 @@ func TestRefresh(t *testing.T) {
 		}
 	}()
 
-	r := newRefresher(client, nil, testDialerID)
+	r := newRefresher(nullLogger{}, client, nil, testDialerID)
 	rr, err := r.performRefresh(context.Background(), cn, RSAKey, false)
 	if err != nil {
 		t.Fatalf("PerformRefresh unexpectedly failed with error: %v", err)
@@ -108,7 +108,7 @@ func TestRefreshFailsFast(t *testing.T) {
 	}
 	defer cleanup()
 
-	r := newRefresher(client, nil, testDialerID)
+	r := newRefresher(nullLogger{}, client, nil, testDialerID)
 	_, err = r.performRefresh(context.Background(), cn, RSAKey, false)
 	if err != nil {
 		t.Fatalf("expected no error, got = %v", err)
@@ -190,7 +190,7 @@ func TestRefreshAdjustsCertExpiry(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
 			ts := &fakeTokenSource{responses: tc.resps}
-			r := newRefresher(client, ts, testDialerID)
+			r := newRefresher(nullLogger{}, client, ts, testDialerID)
 			rr, err := r.performRefresh(context.Background(), cn, RSAKey, true)
 			if err != nil {
 				t.Fatalf("want no error, got = %v", err)
@@ -236,7 +236,7 @@ func TestRefreshWithIAMAuthErrors(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
 			ts := &fakeTokenSource{responses: tc.resps}
-			r := newRefresher(client, ts, testDialerID)
+			r := newRefresher(nullLogger{}, client, ts, testDialerID)
 			_, err := r.performRefresh(context.Background(), cn, RSAKey, true)
 			if err == nil {
 				t.Fatalf("expected get failed error, got = %v", err)
@@ -296,7 +296,7 @@ func TestRefreshMetadataConfigError(t *testing.T) {
 			}
 			defer cleanup()
 
-			r := newRefresher(client, nil, testDialerID)
+			r := newRefresher(nullLogger{}, client, nil, testDialerID)
 			_, err = r.performRefresh(context.Background(), cn, RSAKey, false)
 			if !errors.As(err, &tc.wantErr) {
 				t.Errorf("[%v] PerformRefresh failed with unexpected error, want = %T, got = %v", i, tc.wantErr, err)
@@ -361,7 +361,7 @@ func TestRefreshMetadataRefreshError(t *testing.T) {
 			}
 			defer cleanup()
 
-			r := newRefresher(client, nil, testDialerID)
+			r := newRefresher(nullLogger{}, client, nil, testDialerID)
 			_, err = r.performRefresh(context.Background(), cn, RSAKey, false)
 			if !errors.As(err, &tc.wantErr) {
 				t.Errorf("[%v] PerformRefresh failed with unexpected error, want = %T, got = %v", i, tc.wantErr, err)
@@ -426,7 +426,7 @@ func TestRefreshWithFailedEphemeralCertCall(t *testing.T) {
 		}
 		defer cleanup()
 
-		r := newRefresher(client, nil, testDialerID)
+		r := newRefresher(nullLogger{}, client, nil, testDialerID)
 		_, err = r.performRefresh(context.Background(), cn, RSAKey, false)
 
 		if !errors.As(err, &tc.wantErr) {
@@ -453,7 +453,7 @@ func TestRefreshBuildsTLSConfig(t *testing.T) {
 	}
 	defer cleanup()
 
-	r := newRefresher(client, nil, testDialerID)
+	r := newRefresher(nullLogger{}, client, nil, testDialerID)
 	rr, err := r.performRefresh(context.Background(), cn, RSAKey, false)
 	if err != nil {
 		t.Fatalf("expected no error, got = %v", err)

--- a/options.go
+++ b/options.go
@@ -17,11 +17,12 @@ package cloudsqlconn
 import (
 	"context"
 	"crypto/rsa"
-	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"time"
 
+	"cloud.google.com/go/cloudsqlconn/debug"
 	"cloud.google.com/go/cloudsqlconn/errtype"
 	"cloud.google.com/go/cloudsqlconn/internal/cloudsql"
 	"golang.org/x/oauth2"
@@ -40,6 +41,7 @@ type dialerConfig struct {
 	dialFunc               func(ctx context.Context, network, addr string) (net.Conn, error)
 	refreshTimeout         time.Duration
 	useIAMAuthN            bool
+	logger                 debug.Logger
 	iamLoginTokenSource    oauth2.TokenSource
 	useragents             []string
 	setCredentials         bool
@@ -63,7 +65,7 @@ func WithOptions(opts ...Option) Option {
 // authentication.
 func WithCredentialsFile(filename string) Option {
 	return func(d *dialerConfig) {
-		b, err := ioutil.ReadFile(filename)
+		b, err := os.ReadFile(filename)
 		if err != nil {
 			d.err = errtype.NewConfigError(err.Error(), "n/a")
 			return
@@ -206,6 +208,14 @@ func WithDialFunc(dial func(ctx context.Context, network, addr string) (net.Conn
 func WithIAMAuthN() Option {
 	return func(d *dialerConfig) {
 		d.useIAMAuthN = true
+	}
+}
+
+// WithDebugLogger configures a debug lgoger for reporting on internal
+// operations. By default the debug logger is disabled.
+func WithDebugLogger(l debug.Logger) Option {
+	return func(d *dialerConfig) {
+		d.logger = l
 	}
 }
 


### PR DESCRIPTION
Add support for optional debug logging. Presently, we will log the following:

## Logging for refresh operations
- When a refresh operation starts
- Before the rate limiter is acquired
- After the rate limiter is acquired
- When a refresh operation finishes
- When a refresh operation errors
- When a refresh operation is canceled
- The ephemeral certificate’s expiration time
- The next scheduled refresh

## Logging for connection attempts
- The current certificate’s expiration
- The result of the invalid certificate check (i.e., is “now” after the expiration)
- The result of connecting to the TCP socket including the IP address / PSC DNS name
- The result of the TLS handshake

## Logging for connection cache
- Adding connection info to the cache
- Removing connection info from the cache
