### PR TITLE
refactor: move TLS config creation to ConnectionInfo

### DIFF
--- a/internal/mock/cloudsql.go
+++ b/internal/mock/cloudsql.go
@@ -53,15 +53,19 @@ type FakeCSQLInstance struct {
 	DNSName      string
 	signer       SignFunc
 	clientSigner ClientSignFunc
-	Key          *rsa.PrivateKey
-	Cert         *x509.Certificate
+	// Key is the server's private key
+	Key *rsa.PrivateKey
+	// Cert is the server's certificate
+	Cert *x509.Certificate
 }
 
 func (f FakeCSQLInstance) signedCert() ([]byte, error) {
 	return f.signer(f.Cert, f.Key)
 }
 
-func (f FakeCSQLInstance) clientCert(pubKey *rsa.PublicKey) ([]byte, error) {
+// ClientCert creates an ephemeral client certificate signed with the Cloud SQL
+// instance's private key. The return value is PEM encoded.
+func (f FakeCSQLInstance) ClientCert(pubKey *rsa.PublicKey) ([]byte, error) {
 	return f.clientSigner(f.Cert, f.Key, pubKey)
 }
 

--- a/internal/mock/sqladmin.go
+++ b/internal/mock/sqladmin.go
@@ -178,7 +178,7 @@ func CreateEphemeralSuccess(i FakeCSQLInstance, ct int) *Request {
 				return
 			}
 
-			certBytes, err := i.clientCert(pubKey.(*rsa.PublicKey))
+			certBytes, err := i.ClientCert(pubKey.(*rsa.PublicKey))
 			if err != nil {
 				http.Error(resp, fmt.Errorf("failed to sign client certificate: %v", err).Error(), http.StatusBadRequest)
 				return


### PR DESCRIPTION
This refactor moves all TLS configuration into the connection info type and leaves room for altering the configuration based on the request connection path, rather than hiding the configuration deep within the code that retrieves the ephemeral certificate.