### PR TITLE
feat: add support for a lazy refresh

### DIFF
--- a/internal/cloudsql/lazy.go
+++ b/internal/cloudsql/lazy.go
@@ -1,0 +1,139 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudsql
+
+import (
+	"context"
+	"crypto/rsa"
+	"sync"
+	"time"
+
+	"cloud.google.com/go/cloudsqlconn/debug"
+	"cloud.google.com/go/cloudsqlconn/instance"
+	"golang.org/x/oauth2"
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
+)
+
+// LazyRefreshCache is caches connection info and refreshes the cache only when
+// a caller requests connection info and the current certificate is expired.
+type LazyRefreshCache struct {
+	connName        instance.ConnName
+	logger          debug.Logger
+	key             *rsa.PrivateKey
+	r               refresher
+	mu              sync.Mutex
+	useIAMAuthNDial bool
+	needsRefresh    bool
+	cached          ConnectionInfo
+}
+
+// NewLazyRefreshCache initializes a new LazyRefreshCache.
+func NewLazyRefreshCache(
+	cn instance.ConnName,
+	l debug.Logger,
+	client *sqladmin.Service,
+	key *rsa.PrivateKey,
+	_ time.Duration,
+	ts oauth2.TokenSource,
+	dialerID string,
+	useIAMAuthNDial bool,
+) *LazyRefreshCache {
+	return &LazyRefreshCache{
+		connName: cn,
+		logger:   l,
+		key:      key,
+		r: newRefresher(
+			l,
+			client,
+			ts,
+			dialerID,
+		),
+		useIAMAuthNDial: useIAMAuthNDial,
+	}
+}
+
+// ConnectionInfo returns connection info for the associated instance. New
+// connection info is retrieved under two conditions:
+// - the current connection info's certificate has expired, or
+// - a caller has separately called ForceRefresh
+func (c *LazyRefreshCache) ConnectionInfo(
+	ctx context.Context,
+) (ConnectionInfo, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// strip monotonic clock with UTC()
+	now := time.Now().UTC()
+	// Pad expiration with a buffer to give the client plenty of time to
+	// establish a connection to the server with the certificate.
+	exp := c.cached.Expiration.UTC().Add(-refreshBuffer)
+	if !c.needsRefresh && now.Before(exp) {
+		c.logger.Debugf(
+			"[%v] Connection info is still valid, using cached info",
+			c.connName.String(),
+		)
+		return c.cached, nil
+	}
+
+	c.logger.Debugf(
+		"[%v] Connection info refresh operation started",
+		c.connName.String(),
+	)
+	ci, err := c.r.ConnectionInfo(ctx, c.connName, c.key, c.useIAMAuthNDial)
+	if err != nil {
+		c.logger.Debugf(
+			"[%v] Connection info refresh operation failed, err = %v",
+			c.connName.String(),
+			err,
+		)
+		return ConnectionInfo{}, err
+	}
+	c.logger.Debugf(
+		"[%v] Connection info refresh operation complete",
+		c.connName.String(),
+	)
+	c.logger.Debugf(
+		"[%v] Current certificate expiration = %v",
+		c.connName.String(),
+		ci.Expiration.UTC().Format(time.RFC3339),
+	)
+	c.cached = ci
+	c.needsRefresh = false
+	return ci, nil
+}
+
+// UpdateRefresh updates the refresh operation to either enable or disable IAM
+// authentication for the cached connection info.
+func (c *LazyRefreshCache) UpdateRefresh(useIAMAuthNDial *bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if useIAMAuthNDial != nil && *useIAMAuthNDial != c.useIAMAuthNDial {
+		c.useIAMAuthNDial = *useIAMAuthNDial
+		c.needsRefresh = true
+	}
+}
+
+// ForceRefresh invalidates the caches and configures the next call to
+// ConnectionInfo to retrieve a fresh connection info.
+func (c *LazyRefreshCache) ForceRefresh() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.needsRefresh = true
+}
+
+// Close is a no-op and provided purely for a consistent interface with other
+// caching types.
+func (c *LazyRefreshCache) Close() error {
+	return nil
+}

--- a/internal/cloudsql/lazy_test.go
+++ b/internal/cloudsql/lazy_test.go
@@ -1,0 +1,169 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudsql
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/cloudsqlconn/instance"
+	"cloud.google.com/go/cloudsqlconn/internal/mock"
+	"golang.org/x/oauth2"
+)
+
+func TestLazyRefreshCacheConnectionInfo(t *testing.T) {
+	cn, _ := instance.ParseConnName("my-project:my-region:my-instance")
+	inst := mock.NewFakeCSQLInstance(cn.Project(), cn.Region(), cn.Name())
+	client, cleanup, err := mock.NewSQLAdminService(
+		context.Background(),
+		mock.InstanceGetSuccess(inst, 1),
+		mock.CreateEphemeralSuccess(inst, 1),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := cleanup(); err != nil {
+			t.Fatalf("%v", err)
+		}
+	}()
+	c := NewLazyRefreshCache(
+		testInstanceConnName(), nullLogger{}, client,
+		RSAKey, 30*time.Second, nil, "", false,
+	)
+
+	ci, err := c.ConnectionInfo(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ci.ConnectionName != cn {
+		t.Fatalf("want = %v, got = %v", cn, ci.ConnectionName)
+	}
+	// Request connection info again to ensure it uses the cache and doesn't
+	// send another API call.
+	_, err = c.ConnectionInfo(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLazyRefreshCacheForceRefresh(t *testing.T) {
+	cn, _ := instance.ParseConnName("my-project:my-region:my-instance")
+	inst := mock.NewFakeCSQLInstance(cn.Project(), cn.Region(), cn.Name())
+	client, cleanup, err := mock.NewSQLAdminService(
+		context.Background(),
+		mock.InstanceGetSuccess(inst, 2),
+		mock.CreateEphemeralSuccess(inst, 2),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := cleanup(); err != nil {
+			t.Fatalf("%v", err)
+		}
+	}()
+	c := NewLazyRefreshCache(
+		testInstanceConnName(), nullLogger{}, client,
+		RSAKey, 30*time.Second, nil, "", false,
+	)
+
+	_, err = c.ConnectionInfo(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c.ForceRefresh()
+
+	_, err = c.ConnectionInfo(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// spyTokenSource is a non-threadsafe spy for tracking token source usage
+type spyTokenSource struct {
+	mu    sync.Mutex
+	count int
+}
+
+func (s *spyTokenSource) Token() (*oauth2.Token, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.count++
+	return &oauth2.Token{}, nil
+}
+
+func (s *spyTokenSource) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.count
+}
+
+func TestLazyRefreshCacheUpdateRefresh(t *testing.T) {
+	cn, _ := instance.ParseConnName("my-project:my-region:my-instance")
+	inst := mock.NewFakeCSQLInstance(cn.Project(), cn.Region(), cn.Name())
+	client, cleanup, err := mock.NewSQLAdminService(
+		context.Background(),
+		mock.InstanceGetSuccess(inst, 2),
+		mock.CreateEphemeralSuccess(inst, 2),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := cleanup(); err != nil {
+			t.Fatalf("%v", err)
+		}
+	}()
+
+	spy := &spyTokenSource{}
+	c := NewLazyRefreshCache(
+		testInstanceConnName(), nullLogger{}, client,
+		RSAKey, 30*time.Second, spy, "", false, // disable IAM AuthN at first
+	)
+
+	_, err = c.ConnectionInfo(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := spy.callCount(); got != 0 {
+		t.Fatal("oauth2.TokenSource was called, but should not have been")
+	}
+
+	c.UpdateRefresh(ptr(true))
+
+	_, err = c.ConnectionInfo(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Q: Why should the token source be called twice?
+	// A: Because the refresh code retrieves a token first (1 call) and then
+	//    refreshes it (1 call) for a total of 2 calls.
+	if got, want := spy.callCount(), 2; got != want {
+		t.Fatalf(
+			"oauth2.TokenSource call count, got = %v, want = %v",
+			got, want,
+		)
+	}
+}
+
+func ptr(val bool) *bool {
+	return &val
+}

--- a/options.go
+++ b/options.go
@@ -42,6 +42,7 @@ type dialerConfig struct {
 	refreshTimeout         time.Duration
 	useIAMAuthN            bool
 	logger                 debug.Logger
+	lazyRefresh            bool
 	iamLoginTokenSource    oauth2.TokenSource
 	useragents             []string
 	credentialsUniverse    string
@@ -238,6 +239,19 @@ func WithIAMAuthN() Option {
 func WithDebugLogger(l debug.Logger) Option {
 	return func(d *dialerConfig) {
 		d.logger = l
+	}
+}
+
+// WithLazyRefresh configures the dialer to refresh certificates on an
+// as-needed basis. If a certificate is expired when a connection request
+// occurs, the Go Connector will block the attempt and refresh the certificate
+// immediately. This option is useful when running the Go Connector in
+// environments where the CPU may be throttled, thus preventing a background
+// goroutine from running consistently (e.g., in Cloud Run the CPU is throttled
+// outside of a request context causing the background refresh to fail).
+func WithLazyRefresh() Option {
+	return func(d *dialerConfig) {
+		d.lazyRefresh = true
 	}
 }
 


### PR DESCRIPTION
When creating a Dialer with the WithLazyRefresh option, the connection info and ephemeral certificate will be refreshed only when the cache certificate has expired. No background goroutines run with this option, making it ideal for use in Cloud Run and other serverless environments where the CPU may be throttled.

Fixes #770 