### PR TITLE
fix: retry 50x errors with exponential backoff

### DIFF
--- a/internal/cloudsql/retry.go
+++ b/internal/cloudsql/retry.go
@@ -1,0 +1,108 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudsql
+
+import (
+	"context"
+	"math"
+	"math/rand"
+	"time"
+
+	"google.golang.org/api/googleapi"
+)
+
+// exponentialBackoff calculates a duration based on the attempt i.
+//
+// The formula is:
+//
+//	base * multi^(attempt + 1 + random)
+//
+// With base = 200ms and multi = 1.1618, and random = [0.0, 1.0),
+// the backoff values would fall between the following low and high ends:
+//
+// Attempt  Low (ms)  High (ms)
+//
+//	0         324	     524
+//	1         524	     847
+//	2         847	    1371
+//	3        1371	    2218
+//	4        2218	    3588
+//
+// The theoretical worst case scenario would have a client wait 8.5s in total
+// for an API request to complete (with the first four attempts failing, and
+// the fifth succeeding).
+//
+// This backoff strategy matches the behavior of the Cloud SQL Proxy v1.
+func exponentialBackoff(attempt int) time.Duration {
+	const (
+		base  = float64(200 * time.Millisecond)
+		multi = 1.618
+	)
+	exp := float64(attempt+1) + rand.Float64()
+	return time.Duration(base * math.Pow(multi, exp))
+}
+
+// retry50x will retry any 50x HTTP response up to maxRetries times. The
+// backoffFunc determines the duration to wait between attempts.
+func retry50x[T any](
+	ctx context.Context,
+	f func(context.Context) (*T, error),
+	waitDuration func(int) time.Duration,
+) (*T, error) {
+	const maxRetries = 5
+	var (
+		resp *T
+		err  error
+	)
+	for i := 0; i < maxRetries; i++ {
+		resp, err = f(ctx)
+		// If err is nil, break and return the response.
+		if err == nil {
+			break
+		}
+
+		gErr, ok := err.(*googleapi.Error)
+		// If err is not a googleapi.Error, don't retry.
+		if !ok {
+			return nil, err
+		}
+		// If the error code is not a 50x error, don't retry.
+		if gErr.Code < 500 {
+			return nil, err
+		}
+
+		if wErr := wait(ctx, waitDuration(i)); wErr != nil {
+			err = wErr
+			break
+		}
+
+	}
+	return resp, err
+}
+
+// wait will block until the provided duration passes or the context is
+// canceled, whatever happens first.
+func wait(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	select {
+	case <-ctx.Done():
+		if !timer.Stop() {
+			<-timer.C
+		}
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/cloudsql/retry_test.go
+++ b/internal/cloudsql/retry_test.go
@@ -1,0 +1,157 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudsql
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"google.golang.org/api/googleapi"
+)
+
+func TestRetryExponentialBackoff(t *testing.T) {
+	tcs := []struct {
+		attempt int
+		// The resulting backoff value should be >= low or <= high
+		low  time.Duration
+		high time.Duration
+	}{
+		{
+			attempt: 0,
+			low:     324 * time.Millisecond,
+			high:    524 * time.Millisecond,
+		},
+		{
+			attempt: 1,
+			low:     524 * time.Millisecond,
+			high:    847 * time.Millisecond,
+		},
+		{
+			attempt: 2,
+			low:     847 * time.Millisecond,
+			high:    1371 * time.Millisecond,
+		},
+		{
+			attempt: 3,
+			low:     1371 * time.Millisecond,
+			high:    2218 * time.Millisecond,
+		},
+		{
+			attempt: 4,
+			low:     2218 * time.Millisecond,
+			high:    3588 * time.Millisecond,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(fmt.Sprintf("attempt %d", tc.attempt), func(t *testing.T) {
+			got := exponentialBackoff(tc.attempt)
+			got = got.Round(time.Millisecond)
+			if got < tc.low {
+				t.Fatalf("got was below lower bound, got = %v, want = %v",
+					got, tc.low,
+				)
+			}
+			if got > tc.high {
+				t.Fatalf("got was above upper bound, got = %v, want = %v",
+					got, tc.high,
+				)
+			}
+		})
+	}
+}
+
+func TestRetry(t *testing.T) {
+	tcs := []struct {
+		desc      string
+		f         func(context.Context) (*any, error)
+		wantCount int
+	}{
+		{
+			desc: "unknown errors are not retried",
+			f: func(context.Context) (*any, error) {
+				return nil, errors.New("unknown")
+			},
+			wantCount: 0,
+		},
+		{
+			desc: "do not retry non-50x responses",
+			f: func(context.Context) (*any, error) {
+				return nil, &googleapi.Error{
+					Code: 400,
+				}
+			},
+			wantCount: 0,
+		},
+		{
+			desc: "retry >= 500 HTTP responses with wait function",
+			f: func(context.Context) (*any, error) {
+				return nil, &googleapi.Error{
+					Code: 500,
+				}
+			},
+			wantCount: 5,
+		},
+		{
+			desc: "successful response is not retried",
+			f: func(context.Context) (*any, error) {
+				// no error means success
+				return nil, nil
+			},
+			wantCount: 0,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			var callCount int
+			waitSpy := func(int) time.Duration {
+				callCount++
+				return time.Microsecond
+			}
+
+			retry50x(context.Background(), tc.f, waitSpy)
+
+			if callCount != tc.wantCount {
+				t.Fatalf(
+					"retry call count, want = %v, got = %v",
+					tc.wantCount, callCount,
+				)
+			}
+		})
+	}
+}
+
+func TestRetryExitsEarlyOnContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	fail := func(context.Context) (*any, error) {
+		err := &googleapi.Error{
+			Code:    500,
+			Message: "I always fail",
+		}
+		return nil, err
+	}
+	// Context cancellation short-circuits the wait duration
+	waitOneHour := func(int) time.Duration { return time.Hour }
+
+	_, err := retry50x(ctx, fail, waitOneHour)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want = %v, got = %v", context.Canceled, err)
+	}
+}

--- a/internal/mock/sqladmin.go
+++ b/internal/mock/sqladmin.go
@@ -142,6 +142,36 @@ func InstanceGetSuccess(i FakeCSQLInstance, ct int) *Request {
 	return r
 }
 
+// InstanceGet500 returns a 500 HTTP response
+func InstanceGet500(i FakeCSQLInstance, count int) *Request {
+	return &Request{
+		reqMethod: http.MethodGet,
+		reqPath: fmt.Sprintf(
+			"/sql/v1beta4/projects/%s/instances/%s/connectSettings",
+			i.project, i.name,
+		),
+		reqCt: count,
+		handle: func(resp http.ResponseWriter, _ *http.Request) {
+			http.Error(resp, "server error", http.StatusInternalServerError)
+		},
+	}
+}
+
+// CreateEphemeral500 returns a 500 HTTP response.
+func CreateEphemeral500(i FakeCSQLInstance, count int) *Request {
+	return &Request{
+		reqMethod: http.MethodPost,
+		reqPath: fmt.Sprintf(
+			"/sql/v1beta4/projects/%s/instances/%s:generateEphemeralCert",
+			i.project, i.name,
+		),
+		reqCt: count,
+		handle: func(resp http.ResponseWriter, _ *http.Request) {
+			http.Error(resp, "server error", http.StatusInternalServerError)
+		},
+	}
+}
+
 // CreateEphemeralSuccess returns a Request that responds to the
 // `connect.generateEphemeralCert` SQL Admin endpoint. It responds with a
 // "StatusOK" and a SslCerts object.


### PR DESCRIPTION
This commit adds retry behavior to the two SQL Admin API calls. Any response that results in a 50x error will now be retried up to 5 times with exponential backoff and jitter between each attempt.

The formula used to calculate the duration to wait is:

200ms * 1.618^(attempt + jitter)

This calculation matches what the Cloud SQL Proxy v1 does and will not trigger any significant change in load on the backend.

Fixes #718 