### PR TITLE
chore: make short tests faster

### DIFF
--- a/internal/mock/sqladmin.go
+++ b/internal/mock/sqladmin.go
@@ -47,7 +47,7 @@ func httpClient(requests ...*Request) (*http.Client, string, func() error) {
 				}
 			}
 			// Unexpected requests should throw an error
-			resp.WriteHeader(http.StatusNotImplemented)
+			resp.WriteHeader(http.StatusBadRequest)
 			// TODO: follow error format better?
 			resp.Write([]byte(fmt.Sprintf("unexpected request sent to mock client: %v", req)))
 		},


### PR DESCRIPTION
The test cases covering failure behavior were all inadvertently using exponential backoff in test runs, causing unnecessary slowdowns. This commit disables exponential backoff in tests by having the mock API server return 400 status codes instead of 501s when a request is not recognized. As a result, the exponential backoff logic does not trigger.

This change reduces the time taken by ~75% to about ~5s.