### PR TITLE
feat: invalidate cache on failed IP lookup

### DIFF
--- a/internal/cloudsql/instance.go
+++ b/internal/cloudsql/instance.go
@@ -178,6 +178,24 @@ type ConnectionInfo struct {
 	addrs map[string]string
 }
 
+// NewConnectionInfo initializes a ConnectionInfo struct.
+func NewConnectionInfo(
+	cn instance.ConnName,
+	version string,
+	ipAddrs map[string]string,
+	serverCaCert *x509.Certificate,
+	clientCert tls.Certificate,
+) ConnectionInfo {
+	return ConnectionInfo{
+		addrs:             ipAddrs,
+		ServerCaCert:      serverCaCert,
+		ClientCertificate: clientCert,
+		Expiration:        clientCert.Leaf.NotAfter,
+		DBVersion:         version,
+		ConnectionName:    cn,
+	}
+}
+
 // Addr returns the IP address or DNS name for the given IP type.
 func (c ConnectionInfo) Addr(ipType string) (string, error) {
 	var (

--- a/internal/cloudsql/refresh.go
+++ b/internal/cloudsql/refresh.go
@@ -340,14 +340,9 @@ func (r refresher) ConnectionInfo(
 		return ConnectionInfo{}, fmt.Errorf("refresh failed: %w", ctx.Err())
 	}
 
-	return ConnectionInfo{
-		addrs:             md.ipAddrs,
-		ServerCaCert:      md.serverCaCert,
-		ClientCertificate: ec,
-		Expiration:        ec.Leaf.NotAfter,
-		DBVersion:         md.version,
-		ConnectionName:    cn,
-	}, nil
+	return NewConnectionInfo(
+		cn, md.version, md.ipAddrs, md.serverCaCert, ec,
+	), nil
 }
 
 // supportsAutoIAMAuthN checks that the engine support automatic IAM authn. If


### PR DESCRIPTION
In #768, we removed an implicit behavior of the Go Connector. If a dial attempt requests a non-existent IP type (e.g., client asks for public IP on a private IP only instance), the Connector would invalidate the cache. But with the cleanup PR, we removed that implicit behavior.

In some cases, it might be useful to have this behavior. For example, if a caller starts the Go Connector and tries to connect to a public IP and then later configures public IP, there is no need for a restart.

We made that change in the AlloyDB Go Connector mostly because some internal tests depend on that behavior. See
GoogleCloudPlatform/alloydb-go-connector#555.

Fixes #780