### PR TITLE
refactor: improve naming and key handling in API client

### DIFF
--- a/internal/cloudsql/lazy.go
+++ b/internal/cloudsql/lazy.go
@@ -31,8 +31,7 @@ import (
 type LazyRefreshCache struct {
 	connName        instance.ConnName
 	logger          debug.ContextLogger
-	key             *rsa.PrivateKey
-	r               refresher
+	r               adminAPIClient
 	mu              sync.Mutex
 	useIAMAuthNDial bool
 	needsRefresh    bool
@@ -53,10 +52,10 @@ func NewLazyRefreshCache(
 	return &LazyRefreshCache{
 		connName: cn,
 		logger:   l,
-		key:      key,
-		r: newRefresher(
+		r: newAdminAPIClient(
 			l,
 			client,
+			key,
 			ts,
 			dialerID,
 		),
@@ -92,7 +91,7 @@ func (c *LazyRefreshCache) ConnectionInfo(
 		"[%v] Connection info refresh operation started",
 		c.connName.String(),
 	)
-	ci, err := c.r.ConnectionInfo(ctx, c.connName, c.key, c.useIAMAuthNDial)
+	ci, err := c.r.ConnectionInfo(ctx, c.connName, c.useIAMAuthNDial)
 	if err != nil {
 		c.logger.Debugf(
 			ctx,

--- a/internal/cloudsql/refresh_test.go
+++ b/internal/cloudsql/refresh_test.go
@@ -59,8 +59,8 @@ func TestRefresh(t *testing.T) {
 		}
 	}()
 
-	r := newRefresher(nullLogger{}, client, nil, testDialerID)
-	rr, err := r.ConnectionInfo(context.Background(), cn, RSAKey, false)
+	r := newAdminAPIClient(nullLogger{}, client, RSAKey, nil, testDialerID)
+	rr, err := r.ConnectionInfo(context.Background(), cn, false)
 	if err != nil {
 		t.Fatalf("PerformRefresh unexpectedly failed with error: %v", err)
 	}
@@ -118,8 +118,8 @@ func TestRefreshWithStaticTokenSource(t *testing.T) {
 	t.Cleanup(func() { _ = cleanup() })
 
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "myaccestoken"})
-	r := newRefresher(nullLogger{}, client, ts, testDialerID)
-	ci, err := r.ConnectionInfo(context.Background(), cn, RSAKey, true)
+	r := newAdminAPIClient(nullLogger{}, client, RSAKey, ts, testDialerID)
+	ci, err := r.ConnectionInfo(context.Background(), cn, true)
 	if err != nil {
 		t.Fatalf("PerformRefresh unexpectedly failed with error: %v", err)
 	}
@@ -154,8 +154,8 @@ func TestRefreshRetries50xResponses(t *testing.T) {
 		}
 	}()
 
-	r := newRefresher(nullLogger{}, client, nil, testDialerID)
-	rr, err := r.ConnectionInfo(context.Background(), cn, RSAKey, false)
+	r := newAdminAPIClient(nullLogger{}, client, RSAKey, nil, testDialerID)
+	rr, err := r.ConnectionInfo(context.Background(), cn, false)
 	if err != nil {
 		t.Fatalf("PerformRefresh unexpectedly failed with error: %v", err)
 	}
@@ -179,8 +179,8 @@ func TestRefreshFailsFast(t *testing.T) {
 	}
 	defer cleanup()
 
-	r := newRefresher(nullLogger{}, client, nil, testDialerID)
-	_, err = r.ConnectionInfo(context.Background(), cn, RSAKey, false)
+	r := newAdminAPIClient(nullLogger{}, client, RSAKey, nil, testDialerID)
+	_, err = r.ConnectionInfo(context.Background(), cn, false)
 	if err != nil {
 		t.Fatalf("expected no error, got = %v", err)
 	}
@@ -188,7 +188,7 @@ func TestRefreshFailsFast(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	// context is canceled
-	_, err = r.ConnectionInfo(ctx, cn, RSAKey, false)
+	_, err = r.ConnectionInfo(ctx, cn, false)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled error, got = %v", err)
 	}
@@ -261,8 +261,8 @@ func TestRefreshAdjustsCertExpiry(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
 			ts := &fakeTokenSource{responses: tc.resps}
-			r := newRefresher(nullLogger{}, client, ts, testDialerID)
-			rr, err := r.ConnectionInfo(context.Background(), cn, RSAKey, true)
+			r := newAdminAPIClient(nullLogger{}, client, RSAKey, ts, testDialerID)
+			rr, err := r.ConnectionInfo(context.Background(), cn, true)
 			if err != nil {
 				t.Fatalf("want no error, got = %v", err)
 			}
@@ -307,8 +307,8 @@ func TestRefreshWithIAMAuthErrors(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
 			ts := &fakeTokenSource{responses: tc.resps}
-			r := newRefresher(nullLogger{}, client, ts, testDialerID)
-			_, err := r.ConnectionInfo(context.Background(), cn, RSAKey, true)
+			r := newAdminAPIClient(nullLogger{}, client, RSAKey, ts, testDialerID)
+			_, err := r.ConnectionInfo(context.Background(), cn, true)
 			if err == nil {
 				t.Fatalf("expected get failed error, got = %v", err)
 			}
@@ -367,8 +367,8 @@ func TestRefreshMetadataConfigError(t *testing.T) {
 			}
 			defer cleanup()
 
-			r := newRefresher(nullLogger{}, client, nil, testDialerID)
-			_, err = r.ConnectionInfo(context.Background(), cn, RSAKey, false)
+			r := newAdminAPIClient(nullLogger{}, client, RSAKey, nil, testDialerID)
+			_, err = r.ConnectionInfo(context.Background(), cn, false)
 			if !errors.As(err, &tc.wantErr) {
 				t.Errorf("[%v] PerformRefresh failed with unexpected error, want = %T, got = %v", i, tc.wantErr, err)
 			}
@@ -432,8 +432,8 @@ func TestRefreshMetadataRefreshError(t *testing.T) {
 			}
 			defer cleanup()
 
-			r := newRefresher(nullLogger{}, client, nil, testDialerID)
-			_, err = r.ConnectionInfo(context.Background(), cn, RSAKey, false)
+			r := newAdminAPIClient(nullLogger{}, client, RSAKey, nil, testDialerID)
+			_, err = r.ConnectionInfo(context.Background(), cn, false)
 			if !errors.As(err, &tc.wantErr) {
 				t.Errorf("[%v] PerformRefresh failed with unexpected error, want = %T, got = %v", i, tc.wantErr, err)
 			}
@@ -497,8 +497,8 @@ func TestRefreshWithFailedEphemeralCertCall(t *testing.T) {
 		}
 		defer cleanup()
 
-		r := newRefresher(nullLogger{}, client, nil, testDialerID)
-		_, err = r.ConnectionInfo(context.Background(), cn, RSAKey, false)
+		r := newAdminAPIClient(nullLogger{}, client, RSAKey, nil, testDialerID)
+		_, err = r.ConnectionInfo(context.Background(), cn, false)
 
 		if !errors.As(err, &tc.wantErr) {
 			t.Errorf("[%v] PerformRefresh failed with unexpected error, want = %T, got = %v", i, tc.wantErr, err)


### PR DESCRIPTION
This commit uses a more descriptive name for the code that refreshes connection info. Instead of "refresher," this commit renames the object to "adminAPIClient" to match what we're doing in other connectors.

In addition, the RSA key is no longer stored on the cache but instead passed to the only code that needs the key: the API client.