### PR TITLE
fix: invalidate cache on failed `Warmup` and `EngineVersion`

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -401,7 +401,7 @@ func (d *Dialer) EngineVersion(ctx context.Context, icn string) (string, error) 
 	if err != nil {
 		return "", err
 	}
-	c := d.connectionInfoCache(ctx, cn, nil)
+	c := d.connectionInfoCache(ctx, cn, &d.defaultDialConfig.useIAMAuthN)
 	ci, err := c.ConnectionInfo(ctx)
 	if err != nil {
 		d.removeCached(ctx, cn, c, err)

--- a/dialer.go
+++ b/dialer.go
@@ -459,6 +459,10 @@ func (d *Dialer) Warmup(ctx context.Context, icn string, opts ...DialOption) err
 	}
 	c, err := d.connectionInfoCache(ctx, cn, &cfg.useIAMAuthN)
 	if err != nil {
+		return err
+	}
+	_, err = c.ConnectionInfo(ctx)
+	if err != nil {
 		d.removeCached(ctx, cn, c, err)
 	}
 	return err

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -430,6 +430,69 @@ func TestEngineVersionAvoidsDuplicateRefreshWithIAMAuthN(t *testing.T) {
 	)
 }
 
+func TestEngineVersionRemovesInvalidInstancesFromCache(t *testing.T) {
+	// When a dialer attempts to call EngineVersion for a
+	// non-existent instance, it should delete the instance from
+	// the cache and ensure no background refresh happens (which would be
+	// wasted cycles).
+	d, err := NewDialer(
+		context.Background(),
+		WithTokenSource(mock.EmptyTokenSource{}),
+	)
+	if err != nil {
+		t.Fatalf("expected NewDialer to succeed, but got error: %v", err)
+	}
+
+	// Populate instance map with connection info cache that will always fail
+	// This allows the test to verify the error case path invoking close.
+	badInstanceConnectionName := "doesntexist:us-central1:doesntexist"
+	tcs := []struct {
+		desc string
+		icn  string
+		resp connectionInfoResp
+		opts []DialOption
+	}{
+		{
+			desc: "dialing a bad instance URI",
+			icn:  badInstanceConnectionName,
+			resp: connectionInfoResp{
+				err: errors.New("connect info failed"),
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Manually populate the internal cache with a spy
+			inst, _ := instance.ParseConnName(tc.icn)
+			spy := &spyConnectionInfoCache{
+				connectInfoCalls: []connectionInfoResp{tc.resp},
+			}
+			d.cache[inst] = monitoredCache{
+				connectionInfoCache: spy,
+			}
+
+			_, err = d.EngineVersion(context.Background(), tc.icn)
+			if err == nil {
+				t.Fatal("expected EngineVersion to return error")
+			}
+			// Verify that the connection info cache was closed (to prevent
+			// further failed refresh operations)
+			if got, want := spy.closeWasCalled(), true; got != want {
+				t.Fatal("Close was not called")
+			}
+
+			// Now verify that bad connection name has been deleted from map.
+			d.lock.RLock()
+			_, ok := d.cache[inst]
+			d.lock.RUnlock()
+			if ok {
+				t.Fatal("connection info was not removed from cache")
+			}
+		})
+	}
+}
+
 func TestDialerUserAgent(t *testing.T) {
 	data, err := os.ReadFile("version.txt")
 	if err != nil {


### PR DESCRIPTION
Invalidate the cache and stop background refreshes on failed `Warmup` and `EngineVersion` calls.

Fixes #778 