### PR TITLE
feat: Support configure connections using DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,28 +265,30 @@ the DNS name.
 Adapting the MySQL + database/sql example above:
 
 ```go
-import (
-    "database/sql"
+package main
 
-    "cloud.google.com/go/cloudsqlconn"
-    "cloud.google.com/go/cloudsqlconn/mysql/mysql"
+import (
+	"database/sql"
+
+	"cloud.google.com/go/cloudsqlconn"
+	"cloud.google.com/go/cloudsqlconn/mysql/mysql"
 )
 
 func connect() {
-    cleanup, err := mysql.RegisterDriver("cloudsql-mysql",
-			cloudsqlconn.WithDnsResolver(),
-			cloudsqlconn.WithCredentialsFile("key.json"))
-    if err != nil {
-        // ... handle error
-    }
-    // call cleanup when you're done with the database connection
-    defer cleanup()
+	cleanup, err := mysql.RegisterDriver("cloudsql-mysql",
+		cloudsqlconn.WithDNSResolver(),
+		cloudsqlconn.WithCredentialsFile("key.json"))
+	if err != nil {
+		// ... handle error
+	}
+	// call cleanup when you're done with the database connection
+	defer cleanup()
 
-    db, err := sql.Open(
-        "cloudsql-mysql",
-        "myuser:mypass@cloudsql-mysql(prod-db.mycompany.example.com)/mydb",
-    )
-    // ... etc
+	db, err := sql.Open(
+		"cloudsql-mysql",
+		"myuser:mypass@cloudsql-mysql(prod-db.mycompany.example.com)/mydb",
+	)
+	// ... etc
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ centrally configure which instance in your DNS zone.
 
 #### Configure your DNS Records
 
-Add a DNS SRV record for the Cloud SQL instance to a **private** DNS server 
+Add a DNS TXT record for the Cloud SQL instance to a **private** DNS server 
 or a private Google Cloud DNS Zone used by your application. 
 
 **Note:** You are strongly discouraged from adding DNS records for your 
@@ -251,14 +251,11 @@ internet to discover the Cloud SQL instance name.
 
 For example: suppose you wanted to use the domain name 
 `prod-db.mycompany.example.com` to connect to your database instance 
-`my-project:region:my-instance`. 
+`my-project:region:my-instance`. You would create the following DNS record: 
 
-- Record type: `SRV` 
+- Record type: `TXT` 
 - Name: `prod-db.mycompany.example.com` – This is the domain name used by the application
-- Target: `my-project:region:my-instance` – This is the instance name
-- Port: `3307` – always use port 3307
-- Priority: `0` – always use priority 0 
-- Weight: `1` - always use weight 1
+- Value: `my-project:region:my-instance` – This is the instance name
 
 #### Configure the connector
 
@@ -276,7 +273,9 @@ import (
 )
 
 func connect() {
-    cleanup, err := mysql.RegisterDriver("cloudsql-mysql", cloudsqlconn.WithCredentialsFile("key.json"))
+    cleanup, err := mysql.RegisterDriver("cloudsql-mysql",
+			cloudsqlconn.WithDnsResolver(),
+			cloudsqlconn.WithCredentialsFile("key.json"))
     if err != nil {
         // ... handle error
     }

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -1020,18 +1020,18 @@ func TestDialerInitializesLazyCache(t *testing.T) {
 type fakeResolver struct{}
 
 func (r *fakeResolver) Resolve(_ context.Context, name string) (instance.ConnName, error) {
-	// For TestDialerSuccessfullyDialsDnsSrvRecord
+	// For TestDialerSuccessfullyDialsDnsTxtRecord
 	if name == "db.example.com" {
 		return instance.ParseConnName("my-project:my-region:my-instance")
 	}
 	if name == "db2.example.com" {
 		return instance.ParseConnName("my-project:my-region:my-instance")
 	}
-	// TestDialerFailsDnsSrvRecordMissing
+	// TestDialerFailsDnsTxtRecordMissing
 	return instance.ConnName{}, fmt.Errorf("no resolution for %q", name)
 }
 
-func TestDialerSuccessfullyDialsDnsSrvRecord(t *testing.T) {
+func TestDialerSuccessfullyDialsDnsTxtRecord(t *testing.T) {
 	inst := mock.NewFakeCSQLInstance(
 		"my-project", "my-region", "my-instance",
 	)
@@ -1059,7 +1059,7 @@ func TestDialerSuccessfullyDialsDnsSrvRecord(t *testing.T) {
 	)
 }
 
-func TestDialerFailsDnsSrvRecordMissing(t *testing.T) {
+func TestDialerFailsDnsTxtRecordMissing(t *testing.T) {
 	inst := mock.NewFakeCSQLInstance(
 		"my-project", "my-region", "my-instance",
 	)

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -1019,7 +1019,7 @@ func TestDialerInitializesLazyCache(t *testing.T) {
 
 type fakeResolver struct{}
 
-func (r *fakeResolver) Lookup(_ context.Context, name string) (instance.ConnName, error) {
+func (r *fakeResolver) Resolve(_ context.Context, name string) (instance.ConnName, error) {
 	// For TestDialerSuccessfullyDialsDnsSrvRecord
 	if name == "db.example.com" {
 		return instance.ParseConnName("my-project:my-region:my-instance")

--- a/instance/conn_name.go
+++ b/instance/conn_name.go
@@ -15,6 +15,7 @@
 package instance
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 
@@ -73,4 +74,10 @@ func ParseConnName(cn string) (ConnName, error) {
 		name:    string(m[4]),
 	}
 	return c, nil
+}
+
+// ConnectionNameResolver resolves  This allows an application to replace the default
+// DNSInstanceConnectionNameResolver with a custom implementation.
+type ConnectionNameResolver interface {
+	Resolve(ctx context.Context, name string) (instanceName ConnName, err error)
 }

--- a/instance/conn_name.go
+++ b/instance/conn_name.go
@@ -76,8 +76,12 @@ func ParseConnName(cn string) (ConnName, error) {
 	return c, nil
 }
 
-// ConnectionNameResolver resolves  This allows an application to replace the default
-// DNSInstanceConnectionNameResolver with a custom implementation.
+// ConnectionNameResolver resolves the connection name string into a valid
+// instance name. This allows an application to replace the default
+// resolver with a custom implementation.
 type ConnectionNameResolver interface {
-	Resolve(ctx context.Context, name string) (instanceName ConnName, err error)
+	// Resolve accepts a name, and returns a ConnName with the instance
+	// connection string for the name. If the name cannot be resolved, returns
+	// an error.
+	Resolve(ctx context.Context, name string) (ConnName, error)
 }

--- a/internal/cloudsql/resolver.go
+++ b/internal/cloudsql/resolver.go
@@ -24,6 +24,19 @@ import (
 	"cloud.google.com/go/cloudsqlconn/instance"
 )
 
+// DefaultResolver simply parses the instance name string.
+var DefaultResolver = &ConnNameResolver{}
+
+// ConnNameResolver simply parses instance names.
+type ConnNameResolver struct {
+}
+
+// Resolve returns the instance name, possibly using DNS. This will return an
+// instance.ConnName or an error if it was unable to resolve an instance name.
+func (r *ConnNameResolver) Resolve(_ context.Context, icn string) (instanceName instance.ConnName, err error) {
+	return instance.ParseConnName(icn)
+}
+
 // DefaultInstanceConnectionNameResolver uses the default net.Resolver to find
 // SRV records containing an instance name for a DNS record.
 var DefaultInstanceConnectionNameResolver = &DNSInstanceConnectionNameResolver{
@@ -45,9 +58,9 @@ type DNSInstanceConnectionNameResolver struct {
 	dnsResolver netResolver
 }
 
-// Lookup returns the instance name, possibly using DNS. This will return an
+// Resolve returns the instance name, possibly using DNS. This will return an
 // instance.ConnName or an error if it was unable to resolve an instance name.
-func (r *DNSInstanceConnectionNameResolver) Lookup(ctx context.Context, icn string) (instanceName instance.ConnName, err error) {
+func (r *DNSInstanceConnectionNameResolver) Resolve(ctx context.Context, icn string) (instanceName instance.ConnName, err error) {
 	cn, err := instance.ParseConnName(icn)
 	if err != nil {
 		// The connection name was not project:region:instance

--- a/internal/cloudsql/resolver.go
+++ b/internal/cloudsql/resolver.go
@@ -1,0 +1,118 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudsql
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+
+	"cloud.google.com/go/cloudsqlconn/instance"
+)
+
+// DefaultInstanceConnectionNameResolver uses the default net.Resolver to find
+// SRV records containing an instance name for a DNS record.
+var DefaultInstanceConnectionNameResolver = &DNSInstanceConnectionNameResolver{
+	dnsResolver: net.DefaultResolver,
+}
+
+// netResolver groups the methods on net.Resolver that are used by the DNS
+// resolver implementation. This allows an application to replace the default
+// net.DefaultResolver with a custom implementation. For example: the
+// application may need to connect to a specific DNS server using a specially
+// configured instance of net.Resolver.
+type netResolver interface {
+	LookupSRV(ctx context.Context, service, proto, name string) (cname string, addrs []*net.SRV, err error)
+}
+
+// DNSInstanceConnectionNameResolver can resolve domain names into instance names using
+// SRV records in DNS. Implements InstanceConnectionNameResolver
+type DNSInstanceConnectionNameResolver struct {
+	dnsResolver netResolver
+}
+
+// Lookup returns the instance name, possibly using DNS. This will return an
+// instance.ConnName or an error if it was unable to resolve an instance name.
+func (r *DNSInstanceConnectionNameResolver) Lookup(ctx context.Context, icn string) (instanceName instance.ConnName, err error) {
+	cn, err := instance.ParseConnName(icn)
+	if err != nil {
+		// The connection name was not project:region:instance
+		// Attempt to query a SRV record and see if it works instead.
+		cn, err = r.queryDNS(ctx, icn)
+		if err != nil {
+			return instance.ConnName{}, err
+		}
+	}
+
+	return cn, nil
+}
+
+// queryDNS attempts to resolve a SRV record for the domain name.
+// The DNS SRV record's target field is used as instance name.
+//
+// This handles several conditions where the DNS records may be missing or
+// invalid:
+//   - The domain name resolves to 0 DNS records - return an error
+//   - Some DNS records to not contain a well-formed instance name - return the
+//     first well-formed instance name. If none found return an error.
+//   - The domain name resolves to 2 or more DNS record - return first valid
+//     record when sorted by priority: lowest value first, then by target:
+//     alphabetically.
+func (r *DNSInstanceConnectionNameResolver) queryDNS(ctx context.Context, domainName string) (instance.ConnName, error) {
+	// Attempt to query the SRV records.
+	// This could return a partial error where both err != nil && len(records) > 0.
+	_, records, err := r.dnsResolver.LookupSRV(ctx, "", "", domainName)
+
+	// Process the records returning the first valid SRV record.
+
+	// Sort the record slice so that lowest priority comes first, then
+	// alphabetically by instance name
+	sort.Slice(records, func(i, j int) bool {
+		if records[i].Priority == records[j].Priority {
+			return records[i].Target < records[j].Target
+		}
+		return records[i].Priority < records[j].Priority
+	})
+
+	var perr error
+	// Attempt to parse records, returning the first valid record.
+	for _, record := range records {
+		// Remove trailing '.' from target value.
+		target := strings.TrimRight(record.Target, ".")
+
+		// Parse the target as a CN
+		cn, parseErr := instance.ParseConnName(target)
+		if parseErr != nil {
+			perr = fmt.Errorf("unable to parse SRV for %q: %v", domainName, parseErr)
+			continue
+		}
+		return cn, nil
+	}
+
+	// If resolve failed and no records were found, return the error.
+	if err != nil {
+		return instance.ConnName{}, fmt.Errorf("unable to resolve SRV record for %q: %v", domainName, err)
+	}
+
+	// If all the records failed to parse, return one of the parse errors
+	if perr != nil {
+		return instance.ConnName{}, perr
+	}
+
+	// No records were found, return an error.
+	return instance.ConnName{}, fmt.Errorf("no valid SRV records found for %q", domainName)
+}

--- a/internal/cloudsql/resolver_test.go
+++ b/internal/cloudsql/resolver_test.go
@@ -53,7 +53,7 @@ func TestDNSInstanceNameResolver_Lookup_Success_SrvRecord(t *testing.T) {
 	r := DNSInstanceConnectionNameResolver{
 		dnsResolver: &fakeResolver{},
 	}
-	got, err := r.Lookup(context.Background(), "db.example.com")
+	got, err := r.Resolve(context.Background(), "db.example.com")
 	if err != nil {
 		t.Fatal("got error", err)
 	}
@@ -61,7 +61,7 @@ func TestDNSInstanceNameResolver_Lookup_Success_SrvRecord(t *testing.T) {
 		t.Fatal("Got", got, "Want", want)
 	}
 
-	got, err = r.Lookup(context.Background(), "db2.example.com")
+	got, err = r.Resolve(context.Background(), "db2.example.com")
 	if err != nil {
 		t.Fatal("got error", err)
 	}
@@ -74,7 +74,7 @@ func TestDNSInstanceNameResolver_Lookup_Fails_SrvRecordMissing(t *testing.T) {
 	r := DNSInstanceConnectionNameResolver{
 		dnsResolver: &fakeResolver{},
 	}
-	_, err := r.Lookup(context.Background(), "doesnt-exist.example.com")
+	_, err := r.Resolve(context.Background(), "doesnt-exist.example.com")
 
 	wantMsg := "unable to resolve SRV record for \"doesnt-exist.example.com\""
 	if !strings.Contains(err.Error(), wantMsg) {
@@ -86,7 +86,7 @@ func TestDNSInstanceNameResolver_Lookup_Fails_SrvRecordMalformed(t *testing.T) {
 	r := DNSInstanceConnectionNameResolver{
 		dnsResolver: &fakeResolver{},
 	}
-	_, err := r.Lookup(context.Background(), "malformed.example.com")
+	_, err := r.Resolve(context.Background(), "malformed.example.com")
 	wantMsg := "unable to parse SRV for \"malformed.example.com\""
 	if !strings.Contains(err.Error(), wantMsg) {
 		t.Fatalf("want = %v, got = %v", wantMsg, err)

--- a/internal/cloudsql/resolver_test.go
+++ b/internal/cloudsql/resolver_test.go
@@ -1,0 +1,94 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudsql
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/cloudsqlconn/instance"
+)
+
+type fakeResolver struct{}
+
+func (r *fakeResolver) LookupSRV(_ context.Context, _, _, name string) (cname string, addrs []*net.SRV, err error) {
+	// For TestDialerSuccessfullyDialsDnsSrvRecord
+	if name == "db.example.com" {
+		return "", []*net.SRV{
+			&net.SRV{Target: "my-project:my-region:my-instance."},
+		}, nil
+	}
+	if name == "db2.example.com" {
+		return "", []*net.SRV{
+			&net.SRV{Target: "my-project:my-region:my-instance"},
+		}, nil
+	}
+	// For TestDialerFailsDnsSrvRecordMalformed
+	if name == "malformed.example.com" {
+		return "", []*net.SRV{
+			&net.SRV{Target: "an-invalid-instance-name"},
+		}, nil
+	}
+	return "", nil, fmt.Errorf("no resolution for %v", name)
+}
+
+func TestDNSInstanceNameResolver_Lookup_Success_SrvRecord(t *testing.T) {
+	want, _ := instance.ParseConnName("my-project:my-region:my-instance")
+
+	r := DNSInstanceConnectionNameResolver{
+		dnsResolver: &fakeResolver{},
+	}
+	got, err := r.Lookup(context.Background(), "db.example.com")
+	if err != nil {
+		t.Fatal("got error", err)
+	}
+	if got != want {
+		t.Fatal("Got", got, "Want", want)
+	}
+
+	got, err = r.Lookup(context.Background(), "db2.example.com")
+	if err != nil {
+		t.Fatal("got error", err)
+	}
+	if got != want {
+		t.Fatal("Got", got, "Want", want)
+	}
+}
+
+func TestDNSInstanceNameResolver_Lookup_Fails_SrvRecordMissing(t *testing.T) {
+	r := DNSInstanceConnectionNameResolver{
+		dnsResolver: &fakeResolver{},
+	}
+	_, err := r.Lookup(context.Background(), "doesnt-exist.example.com")
+
+	wantMsg := "unable to resolve SRV record for \"doesnt-exist.example.com\""
+	if !strings.Contains(err.Error(), wantMsg) {
+		t.Fatalf("want = %v, got = %v", wantMsg, err)
+	}
+}
+
+func TestDNSInstanceNameResolver_Lookup_Fails_SrvRecordMalformed(t *testing.T) {
+	r := DNSInstanceConnectionNameResolver{
+		dnsResolver: &fakeResolver{},
+	}
+	_, err := r.Lookup(context.Background(), "malformed.example.com")
+	wantMsg := "unable to parse SRV for \"malformed.example.com\""
+	if !strings.Contains(err.Error(), wantMsg) {
+		t.Fatalf("want = %v, got = %v", wantMsg, err)
+	}
+}

--- a/options.go
+++ b/options.go
@@ -53,7 +53,7 @@ type dialerConfig struct {
 	setCredentials         bool
 	setTokenSource         bool
 	setIAMAuthNTokenSource bool
-	resolver               InstanceConnectionNameResolver
+	resolver               instance.ConnectionNameResolver
 	// err tracks any dialer options that may have failed.
 	err error
 }
@@ -236,18 +236,21 @@ func WithIAMAuthN() Option {
 	}
 }
 
-// InstanceConnectionNameResolver resolves  This allows an application to replace the default
-// DNSInstanceConnectionNameResolver with a custom implementation.
-type InstanceConnectionNameResolver interface {
-	Lookup(ctx context.Context, name string) (instanceName instance.ConnName, err error)
-}
-
 // WithResolver replaces the default DNS resolver with an alternate
 // implementation to use when resolving SRV records containing the
 // instance name. By default, the dialer will use net.DefaultResolver.
-func WithResolver(r InstanceConnectionNameResolver) Option {
+func WithResolver(r instance.ConnectionNameResolver) Option {
 	return func(d *dialerConfig) {
 		d.resolver = r
+	}
+}
+
+// WithDNSResolver will cause the connector resolve domain names into
+// instance names using a DNS TXT record. The connector will also accept
+// explicit instance names.
+func WithDNSResolver() Option {
+	return func(d *dialerConfig) {
+		d.resolver = cloudsql.DefaultInstanceConnectionNameResolver
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -236,21 +236,21 @@ func WithIAMAuthN() Option {
 	}
 }
 
-// WithResolver replaces the default DNS resolver with an alternate
-// implementation to use when resolving SRV records containing the
-// instance name. By default, the dialer will use net.DefaultResolver.
+// WithResolver replaces the default resolver with an alternate
+// implementation to resolve the name in the database DSN to a Cloud SQL
+// instance.
 func WithResolver(r instance.ConnectionNameResolver) Option {
 	return func(d *dialerConfig) {
 		d.resolver = r
 	}
 }
 
-// WithDNSResolver will cause the connector resolve domain names into
-// instance names using a DNS TXT record. The connector will also accept
-// explicit instance names.
+// WithDNSResolver replaces the default resolver (which only resolves instance
+// names) with the DNSResolver, which will attempt to first parse the instance
+// name, and then will attempt to resolve the DNS TXT record.
 func WithDNSResolver() Option {
 	return func(d *dialerConfig) {
-		d.resolver = cloudsql.DefaultInstanceConnectionNameResolver
+		d.resolver = cloudsql.DNSResolver
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -247,7 +247,24 @@ func WithResolver(r instance.ConnectionNameResolver) Option {
 
 // WithDNSResolver replaces the default resolver (which only resolves instance
 // names) with the DNSResolver, which will attempt to first parse the instance
-// name, and then will attempt to resolve the DNS TXT record.
+// name, and then will attempt to resolve the DNS TXT record to determine
+// the instance name.
+//
+// First, add a record for your Cloud SQL instance to a **private** DNS server
+// or a private Google Cloud DNS Zone used by your application.
+//
+// **Note:** You are strongly discouraged from adding DNS records for your
+// Cloud SQL instances to a public DNS server. This would allow anyone on the
+// internet to discover the Cloud SQL instance name.
+//
+// For example: suppose you wanted to use the domain name
+// `prod-db.mycompany.example.com` to connect to your database instance
+// `my-project:region:my-instance`. You would create the following DNS record:
+//
+//   - Record type: `TXT`
+//   - Name: `prod-db.mycompany.example.com` – This is the domain name used by
+//     the application
+//   - Value: `my-project:region:my-instance` – This is the instance name
 func WithDNSResolver() Option {
 	return func(d *dialerConfig) {
 		d.resolver = cloudsql.DNSResolver


### PR DESCRIPTION
The dialer may be configured to use a DNS name to look up the instance 
name instead of configuring the connector with the instance name directly. 

Add a DNS TXT record for the Cloud SQL instance to a **private** DNS server 
or a private Google Cloud DNS Zone used by your application.  For example:

- Record type: `TXT` 
- Name: `prod-db.mycompany.example.com` – This is the domain name used by the application
- Value: `my-project:region:my-instance` – This is the instance connection name

Configure the dialer with the `cloudsqlconn.WithDNSResolver()` option. 

Open a database connection using the DNS name: 

```go
db, err := sql.Open(
    "cloudsql-mysql",
    "myuser:mypass@cloudsql-mysql(prod-db.mycompany.example.com)/mydb",
)
```

Part of #842