### PR TITLE
feat: Automatically reset DNS-configured connections on DNS change

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,8 @@ func connect() {
     // ... etc
 }
 ```
-### Using DNS to identify an instance
+
+### Using DNS domain names to identify instances
 
 The connector can be configured to use DNS to look up an instance. This would
 allow you to configure your application to connect to a database instance, and
@@ -291,6 +292,41 @@ func connect() {
 	// ... etc
 }
 ```
+
+### Automatic fail-over using DNS domain names
+
+When the connector is configured using a domain name, the connector will 
+periodically check if the DNS record for an instance changes. When the connector 
+detects that the domain name refers to a different instance, the connector will
+close all open connections to the old instance. Subsequent connection attempts
+will be directed to the new instance. 
+
+For example: suppose application is configured to connect using the
+domain name `prod-db.mycompany.example.com`. Initially the corporate DNS 
+zone has a TXT record with the value `my-project:region:my-instance`. The
+application establishes connections to the `my-project:region:my-instance` 
+Cloud SQL instance. 
+
+Then, to reconfigure the application using a different database
+instance: `my-project:other-region:my-instance-2`. You update the DNS record
+for `prod-db.mycompany.example.com` with the target 
+`my-project:other-region:my-instance-2`
+
+The connector inside the application detects the change to this
+DNS entry. Now, when the application connects to its database using the 
+domain name `prod-db.mycompany.example.com`, it will connect to the
+`my-project:other-region:my-instance-2` Cloud SQL instance. 
+
+The connector will automatically close all existing connections to
+`my-project:region:my-instance`. This will force the connection pools to 
+establish new connections. Also, it may cause database queries in progress 
+to fail. 
+
+The connector will poll for changes to the DNS name every 30 seconds by default.
+You may configure the frequency of the connections using the option 
+`WithFailoverPeriod(d time.Duration)`. When this is set to 0, the connector will
+disable polling and only check if the DNS record changed when it is
+creating a new connection. 
 
 
 ### Using Options

--- a/internal/cloudsql/instance.go
+++ b/internal/cloudsql/instance.go
@@ -45,6 +45,11 @@ const (
 	// refreshInterval.
 	RefreshTimeout = 60 * time.Second
 
+	// FailoverPeriod is the frequency with which the dialer will check
+	// if the DNS record has changed for connections configured using
+	// a DNS name.
+	FailoverPeriod = 30 * time.Second
+
 	// refreshBurst is the initial burst allowed by the rate limiter.
 	refreshBurst = 2
 )
@@ -163,6 +168,11 @@ func (i *RefreshAheadCache) Close() error {
 	i.cur.cancel()
 	i.next.cancel()
 	return nil
+}
+
+// UseIAMAuthN returns true if this dialer is using IAM AuthN
+func (i *RefreshAheadCache) UseIAMAuthN() bool {
+	return i.useIAMAuthNDial
 }
 
 // ConnectionInfo contains all necessary information to connect securely to the

--- a/internal/cloudsql/lazy.go
+++ b/internal/cloudsql/lazy.go
@@ -141,3 +141,8 @@ func (c *LazyRefreshCache) ForceRefresh() {
 func (c *LazyRefreshCache) Close() error {
 	return nil
 }
+
+// UseIAMAuthN returns true if this dialer is using IAM AuthN
+func (c *LazyRefreshCache) UseIAMAuthN() bool {
+	return c.useIAMAuthNDial
+}

--- a/monitored_cache.go
+++ b/monitored_cache.go
@@ -1,0 +1,151 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudsqlconn
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"cloud.google.com/go/cloudsqlconn/debug"
+	"cloud.google.com/go/cloudsqlconn/instance"
+	"cloud.google.com/go/cloudsqlconn/internal/cloudsql"
+)
+
+// monitoredCache is a wrapper around a connectionInfoCache that tracks the
+// number of connections to the associated instance.
+type monitoredCache struct {
+	openConnsCount *uint64
+	cn             instance.ConnName
+	resolver       instance.ConnectionNameResolver
+	logger         debug.ContextLogger
+
+	// domainNameTicker periodically checks any domain names to see if they
+	// changed.
+	domainNameTicker *time.Ticker
+	closedCh         chan struct{}
+
+	mu        sync.Mutex
+	openConns []*instrumentedConn
+	closed    bool
+
+	connectionInfoCache
+}
+
+func newMonitoredCache(ctx context.Context, cache connectionInfoCache, cn instance.ConnName, failoverPeriod time.Duration, resolver instance.ConnectionNameResolver, logger debug.ContextLogger) *monitoredCache {
+	c := &monitoredCache{
+		openConnsCount:      new(uint64),
+		closedCh:            make(chan struct{}),
+		cn:                  cn,
+		resolver:            resolver,
+		logger:              logger,
+		connectionInfoCache: cache,
+	}
+	if cn.HasDomainName() {
+		c.domainNameTicker = time.NewTicker(failoverPeriod)
+		go func() {
+			for {
+				select {
+				case <-c.domainNameTicker.C:
+					c.purgeClosedConns()
+					c.checkDomainName(ctx)
+				case <-c.closedCh:
+					return
+				}
+			}
+		}()
+
+	}
+
+	return c
+}
+func (c *monitoredCache) isClosed() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.closed
+}
+
+func (c *monitoredCache) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil
+	}
+
+	c.closed = true
+	close(c.closedCh)
+
+	if c.domainNameTicker != nil {
+		c.domainNameTicker.Stop()
+	}
+
+	if atomic.LoadUint64(c.openConnsCount) > 0 {
+		for _, socket := range c.openConns {
+			if !socket.isClosed() {
+				_ = socket.Close() // force socket closed, ok to ignore error.
+			}
+		}
+		atomic.StoreUint64(c.openConnsCount, 0)
+	}
+
+	return c.connectionInfoCache.Close()
+}
+
+func (c *monitoredCache) ForceRefresh() {
+	c.connectionInfoCache.ForceRefresh()
+}
+
+func (c *monitoredCache) UpdateRefresh(b *bool) {
+	c.connectionInfoCache.UpdateRefresh(b)
+}
+func (c *monitoredCache) ConnectionInfo(ctx context.Context) (cloudsql.ConnectionInfo, error) {
+	return c.connectionInfoCache.ConnectionInfo(ctx)
+}
+
+func (c *monitoredCache) purgeClosedConns() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var open []*instrumentedConn
+	for _, s := range c.openConns {
+		if !s.isClosed() {
+			open = append(open, s)
+		}
+	}
+	c.openConns = open
+}
+
+func (c *monitoredCache) checkDomainName(ctx context.Context) {
+	if !c.cn.HasDomainName() {
+		return
+	}
+	newCn, err := c.resolver.Resolve(ctx, c.cn.DomainName())
+	if err != nil {
+		// The domain name could not be resolved.
+		c.logger.Debugf(ctx, "domain name %s for instance %s did not resolve, "+
+			"closing all connections: %v",
+			c.cn.DomainName(), c.cn.Name(), err)
+		c.Close()
+	}
+	if newCn != c.cn {
+		// The instance changed.
+		c.logger.Debugf(ctx, "domain name %s changed from %s to %s, "+
+			"closing all connections.",
+			c.cn.DomainName(), c.cn.Name(), newCn.DomainName())
+		c.Close()
+	}
+
+}

--- a/monitored_cache_test.go
+++ b/monitored_cache_test.go
@@ -1,0 +1,169 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudsqlconn
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/cloudsqlconn/instance"
+)
+
+func TestMonitoredCache_purgeClosedConns(t *testing.T) {
+	cn, _ := instance.ParseConnNameWithDomainName("my-project:my-region:my-instance", "db.example.com")
+	c := newMonitoredCache(context.TODO(),
+		&spyConnectionInfoCache{},
+		cn,
+		10*time.Millisecond,
+		&fakeResolver{entries: map[string]instance.ConnName{"db.example.com": cn}},
+		&testLog{t: t},
+	)
+	c.mu.Lock()
+	// Add connections
+	c.openConns = []*instrumentedConn{
+		&instrumentedConn{closed: false},
+		&instrumentedConn{closed: true},
+	}
+	c.mu.Unlock()
+	// wait for the resolver to run
+	time.Sleep(100 * time.Millisecond)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if got := len(c.openConns); got != 1 {
+		t.Fatalf("got %d, want 1. Expected openConns to only contain open connections", got)
+	}
+
+}
+
+func TestMonitoredCache_checkDomainName_instanceChanged(t *testing.T) {
+	cn, _ := instance.ParseConnNameWithDomainName("my-project:my-region:my-instance", "update.example.com")
+	r := &changingResolver{
+		stage: new(int32),
+	}
+	c := newMonitoredCache(context.TODO(),
+		&spyConnectionInfoCache{},
+		cn,
+		10*time.Millisecond,
+		r,
+		&testLog{t: t},
+	)
+
+	// Dont' change the instance yet. Check that the connection is open.
+	// wait for the resolver to run
+	time.Sleep(100 * time.Millisecond)
+	if c.isClosed() {
+		t.Fatal("got cache closed, want cache open")
+	}
+	// update the domain name
+	atomic.StoreInt32(r.stage, 1)
+
+	// wait for the resolver to run
+	time.Sleep(100 * time.Millisecond)
+	if !c.isClosed() {
+		t.Fatal("got cache open, want cache closed")
+	}
+
+}
+
+func TestMonitoredCache_Close(t *testing.T) {
+	cn, _ := instance.ParseConnNameWithDomainName("my-project:my-region:my-instance", "update.example.com")
+	var closeFuncCalls int32
+
+	r := &changingResolver{
+		stage: new(int32),
+	}
+
+	c := newMonitoredCache(context.TODO(),
+		&spyConnectionInfoCache{},
+		cn,
+		10*time.Millisecond,
+		r,
+		&testLog{t: t},
+	)
+	inc := func() {
+		atomic.AddInt32(&closeFuncCalls, 1)
+	}
+	c.mu.Lock()
+	// set up the state as if there were 2 open connections.
+	c.openConns = []*instrumentedConn{
+		{
+			closed:    false,
+			closeFunc: inc,
+			Conn:      &mockConn{},
+		},
+		{
+			closed:    false,
+			closeFunc: inc,
+			Conn:      &mockConn{},
+		},
+		{
+			closed:    true,
+			closeFunc: inc,
+			Conn:      &mockConn{},
+		},
+	}
+	*c.openConnsCount = 2
+	c.mu.Unlock()
+
+	c.Close()
+	if !c.isClosed() {
+		t.Fatal("got cache open, want cache closed")
+	}
+	// wait for closeFunc() to be called.
+	time.Sleep(100 * time.Millisecond)
+	if got := atomic.LoadInt32(&closeFuncCalls); got != 2 {
+		t.Fatalf("got %d, want 2", got)
+	}
+
+}
+
+type mockConn struct {
+}
+
+func (m *mockConn) Read(_ []byte) (int, error) {
+	return 0, nil
+}
+
+func (m *mockConn) Write(_ []byte) (int, error) {
+	return 0, nil
+}
+
+func (m *mockConn) Close() error {
+	return nil
+}
+
+func (m *mockConn) LocalAddr() net.Addr {
+	return net.TCPAddrFromAddrPort(netip.MustParseAddrPort("127.0.0.1:3307"))
+}
+
+func (m *mockConn) RemoteAddr() net.Addr {
+	return net.TCPAddrFromAddrPort(netip.MustParseAddrPort("127.0.0.1:3307"))
+}
+
+func (m *mockConn) SetDeadline(_ time.Time) error {
+	return nil
+}
+
+func (m *mockConn) SetReadDeadline(_ time.Time) error {
+	return nil
+}
+
+func (m *mockConn) SetWriteDeadline(_ time.Time) error {
+	return nil
+}

--- a/options.go
+++ b/options.go
@@ -54,6 +54,7 @@ type dialerConfig struct {
 	setTokenSource         bool
 	setIAMAuthNTokenSource bool
 	resolver               instance.ConnectionNameResolver
+	failoverPeriod         time.Duration
 	// err tracks any dialer options that may have failed.
 	err error
 }
@@ -268,6 +269,16 @@ func WithResolver(r instance.ConnectionNameResolver) Option {
 func WithDNSResolver() Option {
 	return func(d *dialerConfig) {
 		d.resolver = cloudsql.DNSResolver
+	}
+}
+
+// WithFailoverPeriod will cause the connector to periodically check the SRV DNS
+// records of instance configured using DNS names. By default, this is 30
+// seconds. If this is set to 0, the connector will only check for domain name
+// changes when establishing a new connection.
+func WithFailoverPeriod(f time.Duration) Option {
+	return func(d *dialerConfig) {
+		d.failoverPeriod = f
 	}
 }
 


### PR DESCRIPTION
When a connection is configured using a DNS domain name, the connector will poll the DNS TXT record every 30 seconds. If the value of the DNS record changes, the connector will close all connections to the old instance, and direct new connections to the updated instance. 

Part of #842 


