### PR TITLE
ci: skip integration tests on fork PRs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,6 +27,10 @@ permissions: read-all
 jobs:
   integration:
     name: integration tests
+    # run integration tests on all builds except pull requests from forks or dependabot
+    if: |
+      github.event_name != 'pull_request' || 
+      (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Pull request from forks once merged will still be skipped because `github.event.pull_request.head.repo.full_name` will still be that of the fork.

To combat this we run the job on all events that are not a pull_request (aka `schedule` and `push`)