### PR TITLE
feat: add `bytes_sent` and `bytes_received` as metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,9 @@ Supported metrics include:
 - `cloudsqlconn/refresh_success_count`: The number of successful certificate
   refresh operations
 - `cloudsqlconn/refresh_failure_count`: The number of failed refresh
-  operations.
+  operations
+- `cloudsqlconn/bytes_sent`: The number of bytes sent to Cloud SQL
+- `cloudsqlconn/bytes_received`: The number of bytes received from Cloud SQL
 
 Supported traces include:
 

--- a/dialer.go
+++ b/dialer.go
@@ -481,7 +481,35 @@ func newInstrumentedConn(conn net.Conn, closeFunc func()) *instrumentedConn {
 // is closed.
 type instrumentedConn struct {
 	net.Conn
-	closeFunc func()
+	closeFunc    func()
+	bytesRead    int
+	bytesWritten int
+}
+
+// BytesRead returns the number of bytes read through the connection.
+func (i *instrumentedConn) BytesRead() int {
+	return i.bytesRead
+}
+
+// BytesWritten returns the number of bytes written through the connection.
+func (i *instrumentedConn) BytesWritten() int {
+	return i.bytesWritten
+}
+
+// Read delegates to the underlying net.Conn interface and counts number of
+// bytes read
+func (i *instrumentedConn) Read(b []byte) (n int, err error) {
+	n, err = i.Conn.Read(b)
+	i.bytesRead += n
+	return n, err
+}
+
+// Write delegates to the underlying net.Conn interface and counts number of
+// bytes written
+func (i *instrumentedConn) Write(b []byte) (n int, err error) {
+	n, err = i.Conn.Write(b)
+	i.bytesWritten += n
+	return n, err
 }
 
 // Close delegates to the underlying net.Conn interface and reports the close

--- a/dialer.go
+++ b/dialer.go
@@ -483,19 +483,16 @@ func newInstrumentedConn(conn net.Conn, closeFunc func(), dialerID, connName str
 // is closed.
 type instrumentedConn struct {
 	net.Conn
-	closeFunc    func()
-	dialerID     string
-	connName     string
-	bytesRead    int
-	bytesWritten int
+	closeFunc func()
+	dialerID  string
+	connName  string
 }
 
 // Read delegates to the underlying net.Conn interface and counts number of
 // bytes read
 func (i *instrumentedConn) Read(b []byte) (n int, err error) {
 	n, err = i.Conn.Read(b)
-	i.bytesRead += n
-	trace.RecordBytesReceived(context.Background(), int64(i.bytesRead), i.connName, i.dialerID)
+	trace.RecordBytesReceived(context.Background(), int64(n), i.connName, i.dialerID)
 	return n, err
 }
 
@@ -503,8 +500,7 @@ func (i *instrumentedConn) Read(b []byte) (n int, err error) {
 // bytes written
 func (i *instrumentedConn) Write(b []byte) (n int, err error) {
 	n, err = i.Conn.Write(b)
-	i.bytesWritten += n
-	trace.RecordBytesSent(context.Background(), int64(i.bytesWritten), i.connName, i.dialerID)
+	trace.RecordBytesSent(context.Background(), int64(n), i.connName, i.dialerID)
 	return n, err
 }
 

--- a/dialer.go
+++ b/dialer.go
@@ -488,20 +488,24 @@ type instrumentedConn struct {
 	connName  string
 }
 
-// Read delegates to the underlying net.Conn interface and counts number of
+// Read delegates to the underlying net.Conn interface and records number of
 // bytes read
-func (i *instrumentedConn) Read(b []byte) (n int, err error) {
-	n, err = i.Conn.Read(b)
-	trace.RecordBytesReceived(context.Background(), int64(n), i.connName, i.dialerID)
-	return n, err
+func (i *instrumentedConn) Read(b []byte) (int, error) {
+	bytesRead, err := i.Conn.Read(b)
+	if err == nil {
+		go trace.RecordBytesReceived(context.Background(), int64(bytesRead), i.connName, i.dialerID)
+	}
+	return bytesRead, err
 }
 
-// Write delegates to the underlying net.Conn interface and counts number of
+// Write delegates to the underlying net.Conn interface and records number of
 // bytes written
-func (i *instrumentedConn) Write(b []byte) (n int, err error) {
-	n, err = i.Conn.Write(b)
-	trace.RecordBytesSent(context.Background(), int64(n), i.connName, i.dialerID)
-	return n, err
+func (i *instrumentedConn) Write(b []byte) (int, error) {
+	bytesWritten, err := i.Conn.Write(b)
+	if err == nil {
+		go trace.RecordBytesSent(context.Background(), int64(bytesWritten), i.connName, i.dialerID)
+	}
+	return bytesWritten, err
 }
 
 // Close delegates to the underlying net.Conn interface and reports the close

--- a/internal/trace/metrics.go
+++ b/internal/trace/metrics.go
@@ -105,14 +105,14 @@ var (
 		TagKeys:     []tag.Key{keyInstance, keyDialerID, keyErrorCode},
 	}
 	bytesSentView = &view.View{
-		Name:        "cloudsqlconn//bytes_sent",
+		Name:        "cloudsqlconn/bytes_sent",
 		Measure:     mBytesSent,
 		Description: "The number of bytes sent to Cloud SQL",
 		Aggregation: view.LastValue(),
 		TagKeys:     []tag.Key{keyInstance, keyDialerID},
 	}
 	bytesReceivedView = &view.View{
-		Name:        "cloudsqlconn//bytes_received",
+		Name:        "cloudsqlconn/bytes_received",
 		Measure:     mBytesReceived,
 		Description: "The number of bytes received from Cloud SQL",
 		Aggregation: view.LastValue(),

--- a/internal/trace/metrics.go
+++ b/internal/trace/metrics.go
@@ -57,6 +57,16 @@ var (
 		"A failed certificate refresh operation",
 		stats.UnitDimensionless,
 	)
+	mBytesSent = stats.Int64(
+		"cloudsqlconn/bytes_sent",
+		"The bytes sent to Cloud SQL",
+		stats.UnitDimensionless,
+	)
+	mBytesReceived = stats.Int64(
+		"cloudsqlconn/bytes_received",
+		"The bytes received from Cloud SQL",
+		stats.UnitDimensionless,
+	)
 
 	latencyView = &view.View{
 		Name:        "cloudsqlconn/dial_latency",

--- a/internal/trace/metrics.go
+++ b/internal/trace/metrics.go
@@ -105,14 +105,14 @@ var (
 		TagKeys:     []tag.Key{keyInstance, keyDialerID, keyErrorCode},
 	}
 	bytesSentView = &view.View{
-		Name:        "cloudsqlconn//bytes_sent_count",
+		Name:        "cloudsqlconn//bytes_sent",
 		Measure:     mBytesSent,
 		Description: "The number of bytes sent to Cloud SQL",
 		Aggregation: view.LastValue(),
 		TagKeys:     []tag.Key{keyInstance, keyDialerID},
 	}
 	bytesReceivedView = &view.View{
-		Name:        "cloudsqlconn//bytes_received_count",
+		Name:        "cloudsqlconn//bytes_received",
 		Measure:     mBytesReceived,
 		Description: "The number of bytes received from Cloud SQL",
 		Aggregation: view.LastValue(),

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -16,7 +16,6 @@ package cloudsqlconn
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -162,11 +161,10 @@ func TestDialerWithMetrics(t *testing.T) {
 		t.Fatalf("expected Dial to succeed, but got error: %v", err)
 	}
 	// write to conn to test bytes_sent and bytes_received
-	buf := new(bytes.Buffer)
-	var num uint64 = 1234
-	err = binary.Write(buf, binary.LittleEndian, num)
+	buf := &bytes.Buffer{}
+	err = buf.WriteByte('a')
 	if err != nil {
-		t.Fatalf("binary.Write failed: %v", err)
+		t.Fatalf("buf.WriteByte failed: %v", err)
 	}
 	_, err = conn2.Write(buf.Bytes())
 	if err != nil {
@@ -189,8 +187,8 @@ func TestDialerWithMetrics(t *testing.T) {
 	wantLastValueMetric(t, "cloudsqlconn/open_connections", spy.data(), 2)
 	wantDistributionMetric(t, "cloudsqlconn/dial_latency", spy.data())
 	wantCountMetric(t, "cloudsqlconn/refresh_success_count", spy.data())
-	wantLastValueMetric(t, "cloudsqlconn/bytes_sent", spy.data(), 8)
-	wantLastValueMetric(t, "cloudsqlconn/bytes_received", spy.data(), 8)
+	wantLastValueMetric(t, "cloudsqlconn/bytes_sent", spy.data(), 1)
+	wantLastValueMetric(t, "cloudsqlconn/bytes_received", spy.data(), 1)
 
 	// failure metrics from dialing bogus instance
 	wantCountMetric(t, "cloudsqlconn/dial_failure_count", spy.data())


### PR DESCRIPTION
Adding additional metrics to be reported by Go Connector.

The Connector will now report the number of `bytes_sent` to Cloud SQL
and `bytes_received` from Cloud SQL.