### PR TITLE
chore: set renovate to use Go 1.21

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   "constraints": {
-    "go": "1.20",
+    "go": "1.21",
   },
   "extends": [
     "config:recommended"


### PR DESCRIPTION
Update renovate to Go 1.21