### PR TITLE
chore: Refactor dialer cache concurrency logic. Part of #842.

### DIFF
--- a/dialer_cache.go
+++ b/dialer_cache.go
@@ -1,0 +1,155 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudsqlconn
+
+import (
+	"sync"
+
+	"cloud.google.com/go/cloudsqlconn/debug"
+	"cloud.google.com/go/cloudsqlconn/instance"
+)
+
+// dialerCache manages a thread-safe map of ConnName to monitoredCache. This
+// provides thread safe operations to atomically get or add an entry, scan all
+// entries and update or remove some of them, and to find entries using the
+// domain name or ConnName.
+type dialerCache struct {
+	mu     sync.RWMutex
+	cache  map[instance.ConnName]*monitoredCache
+	logger debug.ContextLogger
+}
+
+// newDialerCache creates and initializes an instance of the dialer cache
+func newDialerCache(logger debug.ContextLogger) *dialerCache {
+	return &dialerCache{
+		cache:  make(map[instance.ConnName]*monitoredCache),
+		logger: logger,
+	}
+}
+
+// findByDomainName returns the entry that matches the domain name.
+// dn - the domain name
+// returns:
+//
+//	instance.ConnName the name of the matching instance
+//	monitoredCache the cached item
+//	bool true when there is a result.
+//
+// This method is thread safe. This method is not re-entrant.
+func (d *dialerCache) findByDomainName(dn string) (instance.ConnName, *monitoredCache, bool) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	for cn, c := range d.cache {
+		if cn.DomainName() == dn {
+			return cn, c, true
+		}
+	}
+	return instance.ConnName{}, nil, false
+}
+
+// get returns the instance matching the cn.
+//
+// This method is not re-entrant.
+func (d *dialerCache) get(cn instance.ConnName) (*monitoredCache, bool) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	c, ok := d.cache[cn]
+	return c, ok
+}
+
+// getOrAdd returns the cache entry, creating it if necessary. This will also
+// take care to remove entries with the same domain name.
+//
+// cn - the connection name to getOrAdd
+// f - the function to use to create a new cache, may return an error
+//
+// returns:
+//
+//	monitoredCache - the cached entry
+//	monitoredCache - the evicted entry if the cache already contained another
+//	entry with the same domain name.
+//	error - an error if the cache entry could not be created.
+//
+// This method is not re-entrant.
+func (d *dialerCache) getOrAdd(cn instance.ConnName, f func() (*monitoredCache, error)) (*monitoredCache, *monitoredCache, error) {
+	var oldC *monitoredCache
+
+	d.mu.RLock()
+	c, ok := d.cache[cn]
+	d.mu.RUnlock()
+	if ok {
+		return c, oldC, nil
+	}
+
+	// If not found, acquire write lock.
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// Look up in the map by CN again
+	c, ok = d.cache[cn]
+	if ok {
+		return c, nil, nil
+	}
+
+	// Try to get an instance with the same domain name but different instance
+	// Remove this instance from the cache, it will be replaced.
+	if cn.HasDomainName() {
+		for oldCn, oc := range d.cache {
+			if oldCn.DomainName() == cn.DomainName() && oldCn != cn {
+				oldC = oc
+				delete(d.cache, oldCn)
+				break
+			}
+		}
+	}
+
+	// Create the new instance and put it in the cache
+	c, err := f()
+	if err != nil {
+		return nil, oldC, err
+	}
+
+	// Instance created successfully. Return it.
+	d.cache[cn] = c
+	return c, oldC, nil
+}
+
+// remove removes the cached item, returning the monitoredCache or nil
+// if no entry was found for cn.
+//
+// This method is not re-entrant.
+func (d *dialerCache) remove(cn instance.ConnName) *monitoredCache {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// Look up in the map by CN again
+	c, ok := d.cache[cn]
+	if ok {
+		delete(d.cache, cn)
+	}
+
+	return c
+}
+
+// clear empties the cache, returning the contents of the cache.
+//
+// This method is not re-entrant.
+func (d *dialerCache) clear() map[instance.ConnName]*monitoredCache {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	old := d.cache
+	d.cache = make(map[instance.ConnName]*monitoredCache)
+	return old
+}

--- a/dialer_cache_test.go
+++ b/dialer_cache_test.go
@@ -1,0 +1,231 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudsqlconn
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/cloudsqlconn/instance"
+)
+
+type testLog struct {
+	t *testing.T
+}
+
+func (l *testLog) Debugf(_ context.Context, f string, args ...interface{}) {
+	l.t.Logf(f, args...)
+}
+
+func TestDialerCache_Get_CreatesInstance(t *testing.T) {
+	cache := newDialerCache(&testLog{t: t})
+	var wantOpenConns uint64 = 10
+	wantCn, _ := instance.ParseConnName("myproject:region:instance")
+
+	c, _, err := cache.getOrAdd(wantCn, func() (*monitoredCache, error) {
+		return &monitoredCache{openConnsCount: &wantOpenConns}, nil
+	})
+
+	if err != nil {
+		t.Error("Got error, want no error", err)
+	}
+	if *c.openConnsCount != wantOpenConns {
+		t.Fatal("Got wrong cache instance")
+	}
+}
+
+func TestDialerCache_Get_UsesExistingInstance(t *testing.T) {
+	cache := newDialerCache(&testLog{t: t})
+	var wantOpenConns uint64 = 10
+	var dontWantOpenConns uint64 = 20
+	wantCn, _ := instance.ParseConnName("myproject:region:instance")
+
+	c, _, err := cache.getOrAdd(wantCn, func() (*monitoredCache, error) {
+		return &monitoredCache{openConnsCount: &wantOpenConns}, nil
+	})
+
+	if err != nil {
+		t.Error("Got error, want no error", err)
+	}
+	if *c.openConnsCount != wantOpenConns {
+		t.Fatal("Got wrong cache instance")
+	}
+
+	c2, _, err := cache.getOrAdd(wantCn, func() (*monitoredCache, error) {
+		return &monitoredCache{openConnsCount: &dontWantOpenConns}, nil
+	})
+	if err != nil {
+		t.Error("Got error, want no error", err)
+	}
+	if *c2.openConnsCount != wantOpenConns {
+		t.Fatal("Got wrong value for cache")
+	}
+
+}
+
+func TestDialerCache_Get_ErrorOnInstanceCreate(t *testing.T) {
+	cache := newDialerCache(&testLog{t: t})
+	wantCn, _ := instance.ParseConnName("myproject:region:instance")
+
+	_, _, err := cache.getOrAdd(wantCn, func() (*monitoredCache, error) {
+		return nil, errors.New("error")
+	})
+
+	if err == nil {
+		t.Error("Got nil error, want error", err)
+	}
+}
+
+func TestDialerCache_Get_ReplaceInstanceWithSameDomain(t *testing.T) {
+	cache := newDialerCache(&testLog{t: t})
+	var wantOpenConns uint64 = 10
+	var wantOpenConns2 uint64 = 20
+	wantCn, _ := instance.ParseConnNameWithDomainName("project:region:instance", "d1.example.com")
+	wantCn2, _ := instance.ParseConnNameWithDomainName("new-project:region:instance2", "d1.example.com")
+
+	// First, put  d1.example.com = project:region:instance
+	c, _, err := cache.getOrAdd(wantCn, func() (*monitoredCache, error) {
+		return &monitoredCache{openConnsCount: &wantOpenConns}, nil
+	})
+	if err != nil {
+		t.Error("Got error, want no error", err)
+	}
+	if *c.openConnsCount != wantOpenConns {
+		t.Fatal("Got wrong cache instance")
+	}
+
+	// Then replace it by domain name with d1.example.com =
+	// new-project:region:instance2
+	c2, oldC, err := cache.getOrAdd(wantCn2, func() (*monitoredCache, error) {
+		return &monitoredCache{openConnsCount: &wantOpenConns2}, nil
+	})
+	if err != nil {
+		t.Error("Got error, want no error", err)
+	}
+	if *oldC.openConnsCount != wantOpenConns {
+		t.Fatal("Got wrong cache instance")
+	}
+	if *c2.openConnsCount != wantOpenConns2 {
+		t.Fatal("Got wrong value for cache")
+	}
+	if len(cache.cache) != 1 {
+		t.Fatal("Got wrong number of cache entries: want 1, got ", len(cache.cache))
+	}
+
+}
+
+func TestDialerCache_Get_ReplaceInstanceErrorWithSameDomain(t *testing.T) {
+	cache := newDialerCache(&testLog{t: t})
+	var wantOpenConns uint64 = 10
+	wantCn, _ := instance.ParseConnNameWithDomainName("project:region:instance", "d1.example.com")
+	wantCn2, _ := instance.ParseConnNameWithDomainName("new-project:region:instance2", "d1.example.com")
+
+	// First, put  d1.example.com = project:region:instance
+	c, _, err := cache.getOrAdd(wantCn, func() (*monitoredCache, error) {
+		return &monitoredCache{openConnsCount: &wantOpenConns}, nil
+	})
+	if err != nil {
+		t.Error("Got error, want no error", err)
+	}
+	if *c.openConnsCount != wantOpenConns {
+		t.Fatal("Got wrong cache instance")
+	}
+
+	// Then replace it by domain name with d1.example.com =
+	// new-project:region:instance2
+	_, oldC, err := cache.getOrAdd(wantCn2, func() (*monitoredCache, error) {
+		return &monitoredCache{}, errors.New("error")
+	})
+	if err == nil {
+		t.Error("Got error, want no error", err)
+	}
+	if *oldC.openConnsCount != wantOpenConns {
+		t.Fatal("Got wrong old instance")
+	}
+	if len(cache.cache) != 0 {
+		t.Fatal("Got wrong number of cache entries: want 0, got ", len(cache.cache))
+	}
+
+}
+
+func TestDialerCache_FindByDomainName_ReturnsValue(t *testing.T) {
+	cache := newDialerCache(&testLog{t: t})
+	var wantOpenConns uint64 = 10
+	wantCn, _ := instance.ParseConnNameWithDomainName("project:region:instance", "d1.example.com")
+	// Add the cache entry
+	cache.getOrAdd(wantCn, func() (*monitoredCache, error) {
+		return &monitoredCache{openConnsCount: &wantOpenConns}, nil
+	})
+
+	cn, _, ok := cache.findByDomainName("d1.example.com")
+	if !ok {
+		t.Fatal("didnt' get d1.example.com")
+	}
+	if cn != wantCn {
+		t.Fatal("got", cn, "want", wantCn)
+	}
+	if _, _, ok := cache.findByDomainName("nope.example.com"); ok {
+		t.Fatal("bad result")
+	}
+}
+
+func TestDialerCache_Remove_CreatesInstance(t *testing.T) {
+	cache := newDialerCache(&testLog{t: t})
+	var wantOpenConns uint64 = 10
+	wantCn, _ := instance.ParseConnName("myproject:region:instance")
+
+	cache.getOrAdd(wantCn, func() (*monitoredCache, error) {
+		return &monitoredCache{openConnsCount: &wantOpenConns}, nil
+	})
+	removedC := cache.remove(wantCn)
+
+	if *removedC.openConnsCount != wantOpenConns {
+		t.Fatal("Got wrong cache instance")
+	}
+	if len(cache.cache) != 0 {
+		t.Fatal("Got wrong number of cache entries: want 0, got ", len(cache.cache))
+	}
+
+}
+
+func TestDialerCache_Clear(t *testing.T) {
+	cache := newDialerCache(&testLog{t: t})
+	var wantOpenConns uint64 = 10
+	var wantOpenConns2 uint64 = 20
+	wantCn, _ := instance.ParseConnNameWithDomainName("project:region:instance", "d1.example.com")
+	wantCn2, _ := instance.ParseConnNameWithDomainName("project:region:instance2", "d2.example.com")
+
+	// Add the cache entry
+	cache.getOrAdd(wantCn, func() (*monitoredCache, error) {
+		return &monitoredCache{openConnsCount: &wantOpenConns}, nil
+	})
+	cache.getOrAdd(wantCn2, func() (*monitoredCache, error) {
+		return &monitoredCache{openConnsCount: &wantOpenConns2}, nil
+	})
+
+	old := cache.clear()
+
+	if _, ok := old[wantCn]; !ok {
+		t.Fatal("didnt' get d1.example.com")
+	}
+	if _, ok := old[wantCn2]; !ok {
+		t.Fatal("didnt' get d2.example.com")
+	}
+
+	if len(cache.cache) != 0 {
+		t.Fatal("Got wrong number of cache entries: want 0, got ", len(cache.cache))
+	}
+}

--- a/instance/conn_name.go
+++ b/instance/conn_name.go
@@ -32,9 +32,10 @@ var (
 // ConnName represents the "instance connection name", in the format
 // "project:region:name".
 type ConnName struct {
-	project string
-	region  string
-	name    string
+	project    string
+	region     string
+	name       string
+	domainName string
 }
 
 func (c *ConnName) String() string {
@@ -56,8 +57,24 @@ func (c *ConnName) Name() string {
 	return c.name
 }
 
+// DomainName returns the domain name used to look up this instance
+func (c *ConnName) DomainName() string {
+	return c.domainName
+}
+
+// HasDomainName returns true if the domain name has a value
+func (c *ConnName) HasDomainName() bool {
+	return c.domainName != ""
+}
+
 // ParseConnName initializes a new ConnName struct.
 func ParseConnName(cn string) (ConnName, error) {
+	return ParseConnNameWithDomainName(cn, "")
+}
+
+// ParseConnNameWithDomainName initializes a new ConnName struct, including the
+// domain name
+func ParseConnNameWithDomainName(cn string, domainName string) (ConnName, error) {
 	b := []byte(cn)
 	m := connNameRegex.FindSubmatch(b)
 	if m == nil {
@@ -69,9 +86,10 @@ func ParseConnName(cn string) (ConnName, error) {
 	}
 
 	c := ConnName{
-		project: string(m[1]),
-		region:  string(m[3]),
-		name:    string(m[4]),
+		project:    string(m[1]),
+		region:     string(m[3]),
+		name:       string(m[4]),
+		domainName: domainName,
 	}
 	return c, nil
 }

--- a/instance/conn_name_test.go
+++ b/instance/conn_name_test.go
@@ -23,11 +23,11 @@ func TestParseConnName(t *testing.T) {
 	}{
 		{
 			"project:region:instance",
-			ConnName{"project", "region", "instance"},
+			ConnName{project: "project", region: "region", name: "instance"},
 		},
 		{
 			"google.com:project:region:instance",
-			ConnName{"google.com:project", "region", "instance"},
+			ConnName{project: "google.com:project", region: "region", name: "instance"},
 		},
 		{
 			"project:instance", // missing region


### PR DESCRIPTION
This moves concurrency code for the map of instance names to connectionInfoCache out of `Dialer` 
and into a new class `dialerCache`. 

This also updates all uses of `monitoredCache` to use a reference rather than a value. The code needs 
to pass instances of `monitoredCache`  by reference before `monitoredCache` can hold thread-safe
logic managing an individual cache entry.