### PR TITLE
fix: update bytes_sent and bytes_received to use Sum

### DIFF
--- a/internal/trace/metrics.go
+++ b/internal/trace/metrics.go
@@ -108,14 +108,14 @@ var (
 		Name:        "cloudsqlconn/bytes_sent",
 		Measure:     mBytesSent,
 		Description: "The number of bytes sent to Cloud SQL",
-		Aggregation: view.LastValue(),
+		Aggregation: view.Sum(),
 		TagKeys:     []tag.Key{keyInstance, keyDialerID},
 	}
 	bytesReceivedView = &view.View{
 		Name:        "cloudsqlconn/bytes_received",
 		Measure:     mBytesReceived,
 		Description: "The number of bytes received from Cloud SQL",
-		Aggregation: view.LastValue(),
+		Aggregation: view.Sum(),
 		TagKeys:     []tag.Key{keyInstance, keyDialerID},
 	}
 


### PR DESCRIPTION
Update `bytes_sent` and `bytes_received` metric views to use the [`Sum`](https://pkg.go.dev/go.opencensus.io/stats/view#Sum)
aggregation instead of `LastValue`.

[godocs for Sum](https://pkg.go.dev/go.opencensus.io/stats/view#Sum):
> Sum indicates that data collected and aggregated with this method will be summed up. For example, accumulated request bytes can be aggregated by using Sum.

Ref: https://github.com/GoogleCloudPlatform/alloydb-go-connector/pull/624/

Thanks @nancynh for pointing this out 😄 