### PR TITLE
feat: Support server certificates from a private CA

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -394,7 +394,7 @@ func (d *Dialer) Dial(ctx context.Context, icn string, opts ...DialOption) (conn
 	}()
 
 	iConn := newInstrumentedConn(tlsConn, func() {
-		n := atomic.AddUint64(c.openConnsCount, ^uint64(0))
+		n := atomic.AddUint64(c.openConnsCount, ^uint64(0)) // c.openConnsCount = c.openConnsCount - 1
 		trace.RecordOpenConnections(context.Background(), int64(n), d.dialerID, cn.String())
 	}, d.dialerID, cn.String())
 

--- a/internal/cloudsql/instance.go
+++ b/internal/cloudsql/instance.go
@@ -241,7 +241,8 @@ func (c ConnectionInfo) TLSConfig() *tls.Config {
 	for _, caCert := range c.ServerCACert {
 		pool.AddCert(caCert)
 	}
-	if c.ServerCAMode == "GOOGLE_MANAGED_CAS_CA" {
+	if c.ServerCAMode == "GOOGLE_MANAGED_CAS_CA" ||
+		c.ServerCAMode == "CUSTOMER_MANAGED_CAS_CA" {
 		// For CAS instances, we can rely on the DNS name to verify the server identity.
 		return &tls.Config{
 			ServerName:   c.DNSName,


### PR DESCRIPTION
The connector will now validate the Subject Alternative Name field for instances using a Private CA. 

These instances will be designated by having ServerCAMode set to `CUSTOMER_MANAGED_CAS_CA`