### PR TITLE
fix: DNS Resolver should include the domain name in the ConnName.

### DIFF
--- a/internal/cloudsql/resolver.go
+++ b/internal/cloudsql/resolver.go
@@ -105,7 +105,7 @@ func (r *DNSInstanceConnectionNameResolver) queryDNS(ctx context.Context, domain
 	// Attempt to parse records, returning the first valid record.
 	for _, record := range records {
 		// Parse the target as a CN
-		cn, parseErr := instance.ParseConnName(record)
+		cn, parseErr := instance.ParseConnNameWithDomainName(record, domainName)
 		if parseErr != nil {
 			perr = fmt.Errorf("unable to parse TXT for %q -> %q : %v", domainName, record, parseErr)
 			continue

--- a/internal/cloudsql/resolver_test.go
+++ b/internal/cloudsql/resolver_test.go
@@ -36,7 +36,7 @@ func (r *fakeResolver) LookupTXT(_ context.Context, name string) (addrs []string
 }
 
 func TestDNSInstanceNameResolver_Lookup_Success_TxtRecord(t *testing.T) {
-	want, _ := instance.ParseConnName("my-project:my-region:my-instance")
+	want, _ := instance.ParseConnNameWithDomainName("my-project:my-region:my-instance", "db.example.com")
 
 	r := DNSInstanceConnectionNameResolver{
 		dnsResolver: &fakeResolver{


### PR DESCRIPTION
The DNS Resolver should return a ConnName with the resolved instance name and the DNS name. 