### PR TITLE
feat: drop support for Go 1.21

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   "constraints": {
-    "go": "1.21",
+    "go": "1.22",
   },
   "extends": [
     "config:recommended"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -138,10 +138,7 @@ jobs:
     strategy:
       matrix:
         goarch: ["", "386"]
-        go-version: ["1.21", "1.23"]
-        exclude:
-          - goarch: "386"
-            go-version: "1.21"
+        go-version: ["1.22", "1.23"]
       fail-fast: false
     permissions:
       contents: read

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module cloud.google.com/go/cloudsqlconn
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-sql-driver/mysql v1.8.1


### PR DESCRIPTION
Drop support for Go 1.21 as new version support policy is to support latest 
two major versions (Go 1.22 and 1.23).

Closes #905 