### PR TITLE
chore(ci): Add go 1.22 to list of unit test targets.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -138,7 +138,7 @@ jobs:
     strategy:
       matrix:
         goarch: ["", "386"]
-        go-version: ["1.21", "1.23"]
+        go-version: ["1.21", "1.22", "1.23"]
         exclude:
           - goarch: "386"
             go-version: "1.21"


### PR DESCRIPTION
We now require branch PRs to pass go 1.22 unit tests. This enables the jobs for 1.22 unit tests.