### PR TITLE
refactor: remove duplicate tok.Token()

### DIFF
--- a/internal/cloudsql/lazy_test.go
+++ b/internal/cloudsql/lazy_test.go
@@ -153,10 +153,7 @@ func TestLazyRefreshCacheUpdateRefresh(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Q: Why should the token provider be called twice?
-	// A: Because the refresh code retrieves a token first (1 call) and then
-	//    refreshes it (1 call) for a total of 2 calls.
-	if got, want := spy.callCount(), 2; got != want {
+	if got, want := spy.callCount(), 1; got != want {
 		t.Fatalf(
 			"auth.TokenProvider call count, got = %v, want = %v",
 			got, want,

--- a/internal/cloudsql/refresh.go
+++ b/internal/cloudsql/refresh.go
@@ -171,14 +171,6 @@ func fetchEphemeralCert(
 				tokErr,
 			)
 		}
-		tok, tokErr = tp.Token(ctx)
-		if tokErr != nil {
-			return tls.Certificate{}, errtype.NewRefreshError(
-				"failed to get Oauth2 token",
-				inst.String(),
-				tokErr,
-			)
-		}
 		req.AccessToken = tok.Value
 	}
 	resp, err := retry50x(ctx, func(ctx2 context.Context) (*sqladmin.GenerateEphemeralCertResponse, error) {

--- a/internal/cloudsql/refresh_test.go
+++ b/internal/cloudsql/refresh_test.go
@@ -293,14 +293,6 @@ func TestRefreshWithIAMAuthErrors(t *testing.T) {
 			resps:     []tokenResp{{tok: nil, err: errors.New("fetch failed")}},
 			wantCount: 1,
 		},
-		{
-			desc: "when refreshing a token fails",
-			resps: []tokenResp{
-				{tok: &auth.Token{}, err: nil},
-				{tok: nil, err: errors.New("refresh failed")},
-			},
-			wantCount: 2,
-		},
 	}
 	cn := testInstanceConnName()
 	inst := mock.NewFakeCSQLInstance("my-project", "my-region", "my-instance")

--- a/internal/cloudsql/refresh_test.go
+++ b/internal/cloudsql/refresh_test.go
@@ -240,7 +240,6 @@ func TestRefreshAdjustsCertExpiry(t *testing.T) {
 		{
 			desc: "when the token's expiration comes BEFORE the cert",
 			resps: []tokenResp{
-				{tok: &auth.Token{}},
 				{tok: &auth.Token{Expiry: t1}},
 			},
 			wantExpiry: t1,
@@ -248,7 +247,6 @@ func TestRefreshAdjustsCertExpiry(t *testing.T) {
 		{
 			desc: "when the token's expiration comes AFTER the cert",
 			resps: []tokenResp{
-				{tok: &auth.Token{}},
 				{tok: &auth.Token{Expiry: t2}},
 			},
 			wantExpiry: certExpiry,


### PR DESCRIPTION
In #909 we removed the need for `refreshToken()` but instead of removing the code we switched it to `tok.Token()`
which is already called so we can remove the duplicate.

https://github.com/GoogleCloudPlatform/cloud-sql-go-connector/blob/dcd433d098bbf0b1cdd23037a01770bd72485302/internal/cloudsql/refresh.go#L164-L181