### PR TITLE
fix: correct default usage for `WithQuotaProject` and `WithUserAgent`

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -221,9 +221,6 @@ func NewDialer(ctx context.Context, opts ...Option) (*Dialer, error) {
 		return nil, errUseTokenSource
 	}
 
-	// Add this to the end to make sure it's not overridden
-	cfg.sqladminOpts = append(cfg.sqladminOpts, option.WithUserAgent(strings.Join(cfg.useragents, " ")))
-
 	// If callers have not provided a credential source, either explicitly with
 	// WithTokenSource or implicitly with WithCredentialsJSON etc., then use
 	// default credentials
@@ -268,8 +265,12 @@ func NewDialer(ctx context.Context, opts ...Option) (*Dialer, error) {
 		if !cfg.setHTTPClient {
 			cfg.sqladminOpts = append(cfg.sqladminOpts, option.WithHTTPClient(authClient))
 		}
-	} else if cfg.quotaProject != "" {
-		cfg.sqladminOpts = append(cfg.sqladminOpts, option.WithQuotaProject(cfg.quotaProject))
+	} else {
+		// Add this to the end to make sure it's not overridden
+		cfg.sqladminOpts = append(cfg.sqladminOpts, option.WithUserAgent(strings.Join(cfg.useragents, " ")))
+		if cfg.quotaProject != "" {
+			cfg.sqladminOpts = append(cfg.sqladminOpts, option.WithQuotaProject(cfg.quotaProject))
+		}
 	}
 
 	client, err := sqladmin.NewService(ctx, cfg.sqladminOpts...)

--- a/e2e_postgres_test.go
+++ b/e2e_postgres_test.go
@@ -47,6 +47,7 @@ var (
 	postgresCustomerCASPass     = os.Getenv("POSTGRES_CUSTOMER_CAS_PASS")            // Password for the database user for customer CAS instances; be careful when entering a password on the command line (it may go into your terminal's history).
 	postgresDB                  = os.Getenv("POSTGRES_DB")                           // Name of the database to connect to.
 	postgresUserIAM             = os.Getenv("POSTGRES_USER_IAM")                     // Name of database IAM user.
+	project                     = os.Getenv("GOOGLE_CLOUD_PROJECT")                  // Name of the Google Cloud Platform project.
 )
 
 func requirePostgresVars(t *testing.T) {
@@ -69,6 +70,8 @@ func requirePostgresVars(t *testing.T) {
 		t.Fatal("'POSTGRES_DB' env var not set")
 	case postgresUserIAM:
 		t.Fatal("'POSTGRES_USER_IAM' env var not set")
+	case project:
+		t.Fatal("'GOOGLE_CLOUD_PROJECT' env var not set")
 	}
 }
 
@@ -148,6 +151,54 @@ func TestPostgresCASConnect(t *testing.T) {
 	// postgresConnName takes the form of 'project:region:instance'.
 	config.ConnConfig.DialFunc = func(ctx context.Context, _ string, _ string) (net.Conn, error) {
 		return d.Dial(ctx, postgresCASConnName)
+	}
+
+	// Interact with the driver directly as you normally would
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		t.Fatalf("failed to create pool: %s", err)
+	}
+	// ... etc
+
+	defer cleanup()
+	defer pool.Close()
+
+	var now time.Time
+	err = pool.QueryRow(context.Background(), "SELECT NOW()").Scan(&now)
+	if err != nil {
+		t.Fatalf("QueryRow failed: %s", err)
+	}
+	t.Log(now)
+}
+
+func TestPostgresConnectWithQuotaProject(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Postgres integration tests")
+	}
+	requirePostgresVars(t)
+
+	ctx := context.Background()
+
+	// Configure the driver to connect to the database
+	dsn := fmt.Sprintf("user=%s password=%s dbname=%s sslmode=disable", postgresUser, postgresPass, postgresDB)
+	config, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("failed to parse pgx config: %v", err)
+	}
+
+	// Create a new dialer with any options
+	d, err := cloudsqlconn.NewDialer(ctx, cloudsqlconn.WithQuotaProject(project))
+	if err != nil {
+		t.Fatalf("failed to init Dialer: %v", err)
+	}
+
+	// call cleanup when you're done with the database connection to close dialer
+	cleanup := func() error { return d.Close() }
+
+	// Tell the driver to use the Cloud SQL Go Connector to create connections
+	// postgresConnName takes the form of 'project:region:instance'.
+	config.ConnConfig.DialFunc = func(ctx context.Context, _ string, _ string) (net.Conn, error) {
+		return d.Dial(ctx, postgresConnName)
 	}
 
 	// Interact with the driver directly as you normally would

--- a/options.go
+++ b/options.go
@@ -47,6 +47,7 @@ type dialerConfig struct {
 	logger                 debug.ContextLogger
 	lazyRefresh            bool
 	clientUniverseDomain   string
+	quotaProject           string
 	authCredentials        *auth.Credentials
 	iamLoginTokenProvider  auth.TokenProvider
 	useragents             []string
@@ -210,7 +211,7 @@ func WithUniverseDomain(ud string) Option {
 // WithQuotaProject returns an Option that specifies the project used for quota and billing purposes.
 func WithQuotaProject(p string) Option {
 	return func(cfg *dialerConfig) {
-		cfg.sqladminOpts = append(cfg.sqladminOpts, apiopt.WithQuotaProject(p))
+		cfg.quotaProject = p
 	}
 }
 


### PR DESCRIPTION
In #909 we started leveraging [`httptransport.NewClient`](https://pkg.go.dev/cloud.google.com/go/auth/httptransport#NewClient) with [`Option.WithHTTPClient`](https://pkg.go.dev/google.golang.org/api/option#WithHTTPClient).

https://github.com/GoogleCloudPlatform/cloud-sql-go-connector/blob/42d001979ffbe9e5f1323b54eace20a4eb23dd7a/dialer.go#L250-L260

However `WithHTTPClient` can not be used with `WithQuotaProject` or with `WithUserAgent` Options.

If auth client is being used, we must set the headers manually.

Fixes #918 