### PR TITLE
fix: pass headers to transport

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -104,6 +104,7 @@ jobs:
           SQLSERVER_USER: "${{ steps.secrets.outputs.SQLSERVER_USER }}"
           SQLSERVER_PASS: "${{ steps.secrets.outputs.SQLSERVER_PASS }}"
           SQLSERVER_DB: "${{ steps.secrets.outputs.SQLSERVER_DB }}"
+          QUOTA_PROJECT: "${{ vars.GOOGLE_CLOUD_PROJECT }}"
         # specifying bash shell ensures a failure in a piped process isn't lost by using `set -eo pipefail`
         shell: bash
         run: |

--- a/dialer.go
+++ b/dialer.go
@@ -254,6 +254,7 @@ func NewDialer(ctx context.Context, opts ...Option) (*Dialer, error) {
 		}
 
 		authClient, err := httptransport.NewClient(&httptransport.Options{
+			Headers:        headers,
 			Credentials:    cfg.authCredentials,
 			UniverseDomain: cfg.getClientUniverseDomain(),
 		})

--- a/e2e_postgres_test.go
+++ b/e2e_postgres_test.go
@@ -47,7 +47,7 @@ var (
 	postgresCustomerCASPass     = os.Getenv("POSTGRES_CUSTOMER_CAS_PASS")            // Password for the database user for customer CAS instances; be careful when entering a password on the command line (it may go into your terminal's history).
 	postgresDB                  = os.Getenv("POSTGRES_DB")                           // Name of the database to connect to.
 	postgresUserIAM             = os.Getenv("POSTGRES_USER_IAM")                     // Name of database IAM user.
-	project                     = os.Getenv("GOOGLE_CLOUD_PROJECT")                  // Name of the Google Cloud Platform project.
+	project                     = os.Getenv("QUOTA_PROJECT")                         // Name of the Google Cloud Platform project to use for quota and billing.
 )
 
 func requirePostgresVars(t *testing.T) {
@@ -71,7 +71,7 @@ func requirePostgresVars(t *testing.T) {
 	case postgresUserIAM:
 		t.Fatal("'POSTGRES_USER_IAM' env var not set")
 	case project:
-		t.Fatal("'GOOGLE_CLOUD_PROJECT' env var not set")
+		t.Fatal("'QUOTA_PROJECT' env var not set")
 	}
 }
 


### PR DESCRIPTION
In https://github.com/GoogleCloudPlatform/cloud-sql-go-connector/pull/920 we set the headers for quota project and user agent but failed to actually pass the headers to the underlying transport.

This PR corrects that silly mistake.