### PR TITLE
feat: add support for Go 1.24 and drop Go 1.22

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   "constraints": {
-    "go": "1.22",
+    "go": "1.23",
   },
   "extends": [
     "config:recommended"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: "1.23"
+          go-version: "1.24"
         if: ${{ matrix.language == 'go' }}
 
       # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Checkout base branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: "1.23"
+          go-version: "1.24"
           check-latest: true
       - id: govulncheck
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: "1.23"
+          go-version: "1.24"
       - name: go mod tidy
         run: |
           go mod tidy && git diff --exit-code

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - id: auth
         name: Authenticate to Google Cloud
@@ -143,7 +143,7 @@ jobs:
     strategy:
       matrix:
         goarch: ["", "386"]
-        go-version: ["1.22", "1.23"]
+        go-version: ["1.23", "1.24"]
       fail-fast: false
     permissions:
       contents: read

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module cloud.google.com/go/cloudsqlconn
 
-go 1.22.7
+go 1.23
 
-toolchain go1.22.11
+toolchain go1.23.6
 
 require (
 	cloud.google.com/go/auth v0.14.1


### PR DESCRIPTION
Go 1.22 is EOL: https://endoflife.date/go

Go 1.24 was just released