### PR TITLE
chore: audit csql test instances

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -64,7 +64,6 @@ jobs:
         with:
           secrets: |-
             MYSQL_CONNECTION_NAME:${{ vars.GOOGLE_CLOUD_PROJECT }}/MYSQL_CONNECTION_NAME
-            MYSQL_IAM_CONNECTION_NAME:${{ vars.GOOGLE_CLOUD_PROJECT }}/MYSQL_IAM_CONNECTION_NAME
             MYSQL_USER:${{ vars.GOOGLE_CLOUD_PROJECT }}/MYSQL_USER
             MYSQL_USER_IAM:${{ vars.GOOGLE_CLOUD_PROJECT }}/MYSQL_USER_IAM_GO
             MYSQL_PASS:${{ vars.GOOGLE_CLOUD_PROJECT }}/MYSQL_PASS
@@ -86,7 +85,6 @@ jobs:
       - name: Run tests
         env:
           MYSQL_CONNECTION_NAME: "${{ steps.secrets.outputs.MYSQL_CONNECTION_NAME }}"
-          MYSQL_IAM_CONNECTION_NAME: "${{ steps.secrets.outputs.MYSQL_IAM_CONNECTION_NAME }}"
           MYSQL_USER: "${{ steps.secrets.outputs.MYSQL_USER }}"
           MYSQL_USER_IAM: "${{ steps.secrets.outputs.MYSQL_USER_IAM }}"
           MYSQL_PASS: "${{ steps.secrets.outputs.MYSQL_PASS }}"

--- a/e2e_mysql_test.go
+++ b/e2e_mysql_test.go
@@ -32,7 +32,7 @@ var (
 	// "Cloud SQL MySQL instance connection name, in the form of 'project:region:instance'.
 	mysqlConnName = os.Getenv("MYSQL_CONNECTION_NAME")
 	// "Cloud SQL MySQL instance connection name, in the form of 'project:region:instance'.
-	mysqlIAMConnName = os.Getenv("MYSQL_IAM_CONNECTION_NAME")
+	mysqlIAMConnName = os.Getenv("MYSQL_CONNECTION_NAME")
 	// Name of database user.
 	mysqlUser = os.Getenv("MYSQL_USER")
 	// Name of database IAM user.

--- a/e2e_mysql_test.go
+++ b/e2e_mysql_test.go
@@ -31,8 +31,6 @@ import (
 var (
 	// "Cloud SQL MySQL instance connection name, in the form of 'project:region:instance'.
 	mysqlConnName = os.Getenv("MYSQL_CONNECTION_NAME")
-	// "Cloud SQL MySQL instance connection name, in the form of 'project:region:instance'.
-	mysqlIAMConnName = os.Getenv("MYSQL_CONNECTION_NAME")
 	// Name of database user.
 	mysqlUser = os.Getenv("MYSQL_USER")
 	// Name of database IAM user.
@@ -92,7 +90,7 @@ func TestMySQLDriver(t *testing.T) {
 			desc:         "auto IAM authn",
 			driverName:   "cloudsql-mysql-iam",
 			opts:         []cloudsqlconn.Option{cloudsqlconn.WithIAMAuthN()},
-			instanceName: mysqlIAMConnName,
+			instanceName: mysqlConnName,
 			user:         mysqlIAMUser,
 			password:     "password",
 		},


### PR DESCRIPTION
Consolidate use of Cloud SQL instances for end to end tests in the following cases:
1. MySQL IAM 
2. Postgres IAM 