### PR TITLE
feat: Use standard TLS hostname validation for instances with DNS names

### DIFF
--- a/e2e_mysql_test.go
+++ b/e2e_mysql_test.go
@@ -15,15 +15,12 @@
 package cloudsqlconn_test
 
 import (
-	"context"
 	"database/sql"
-	"fmt"
 	"os"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/cloudsqlconn"
-	"cloud.google.com/go/cloudsqlconn/instance"
 	"cloud.google.com/go/cloudsqlconn/mysql/mysql"
 	gomysql "github.com/go-sql-driver/mysql"
 )
@@ -55,16 +52,6 @@ func requireMySQLVars(t *testing.T) {
 	}
 }
 
-type mockResolver struct {
-}
-
-func (r *mockResolver) Resolve(_ context.Context, name string) (instanceName instance.ConnName, err error) {
-	if name == "mysql.example.com" {
-		return instance.ParseConnNameWithDomainName(mysqlConnName, "mysql.example.com")
-	}
-	return instance.ConnName{}, fmt.Errorf("no resolution for %v", name)
-}
-
 func TestMySQLDriver(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping MySQL integration tests")
@@ -93,14 +80,6 @@ func TestMySQLDriver(t *testing.T) {
 			instanceName: mysqlConnName,
 			user:         mysqlIAMUser,
 			password:     "password",
-		},
-		{
-			desc:         "with dns",
-			driverName:   "cloudsql-mysql-dns",
-			opts:         []cloudsqlconn.Option{cloudsqlconn.WithResolver(&mockResolver{})},
-			instanceName: "mysql.example.com",
-			user:         mysqlUser,
-			password:     mysqlPass,
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module cloud.google.com/go/cloudsqlconn
 
 go 1.23.0
 
-toolchain go1.23.7
-
 require (
 	cloud.google.com/go/auth v0.15.0
 	cloud.google.com/go/auth/oauth2adapt v0.2.7
@@ -16,8 +14,8 @@ require (
 	golang.org/x/net v0.37.0
 	golang.org/x/oauth2 v0.28.0
 	golang.org/x/time v0.11.0
-	google.golang.org/api v0.224.0
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250227231956-55c901821b1e
+	google.golang.org/api v0.225.0
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250303144028-a0af3efb3deb
 	google.golang.org/grpc v1.71.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -305,8 +305,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-google.golang.org/api v0.224.0 h1:Ir4UPtDsNiwIOHdExr3fAj4xZ42QjK7uQte3lORLJwU=
-google.golang.org/api v0.224.0/go.mod h1:3V39my2xAGkodXy0vEqcEtkqgw2GtrFL5WuBZlCTCOQ=
+google.golang.org/api v0.225.0 h1:+4/IVqBQm0MV5S+JW3kdEGC1WtOmM2mXN1LKH1LdNlw=
+google.golang.org/api v0.225.0/go.mod h1:WP/0Xm4LVvMOCldfvOISnWquSRWbG2kArDZcg+W2DbY=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
@@ -314,8 +314,8 @@ google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422 h1:GVIKPyP/kLIyVOgOnTwFOrvQaQUzOzGMCxgFUOEmm24=
 google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422/go.mod h1:b6h1vNKhxaSoEI+5jc3PJUCustfli/mRab7295pY7rw=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20250227231956-55c901821b1e h1:YA5lmSs3zc/5w+xsRcHqpETkaYyK63ivEPzNTcUUlSA=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20250227231956-55c901821b1e/go.mod h1:LuRYeWDFV6WOn90g357N17oMCaxpgCnbi/44qJvDn2I=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20250303144028-a0af3efb3deb h1:TLPQVbx1GJ8VKZxz52VAxl1EBgKXXbTiU9Fc5fZeLn4=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20250303144028-a0af3efb3deb/go.mod h1:LuRYeWDFV6WOn90g357N17oMCaxpgCnbi/44qJvDn2I=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=

--- a/internal/mock/certs.go
+++ b/internal/mock/certs.go
@@ -246,9 +246,9 @@ func (ct *TLSCertificates) generateServerCertWithCn(cn string) *x509.Certificate
 // serverChain creates a []tls.Certificate for use with a TLS server socket.
 // serverCAMode controls whether this returns a legacy or CAS server
 // certificate.
-func (ct *TLSCertificates) serverChain(serverCAMode string) []tls.Certificate {
+func (ct *TLSCertificates) serverChain(useStandardTLSValidation bool) []tls.Certificate {
 	// if this server is running in legacy mode
-	if serverCAMode == "" || serverCAMode == "GOOGLE_MANAGED_INTERNAL_CA" {
+	if !useStandardTLSValidation {
 		return []tls.Certificate{{
 			Certificate: [][]byte{ct.serverCert.Raw, ct.serverCaCert.Raw},
 			PrivateKey:  ct.serverKey,

--- a/internal/mock/sqladmin.go
+++ b/internal/mock/sqladmin.go
@@ -129,6 +129,7 @@ func InstanceGetSuccess(i FakeCSQLInstance, ct int) *Request {
 			db := &sqladmin.ConnectSettings{
 				BackendType:     i.backendType,
 				DatabaseVersion: i.dbVersion,
+				DnsNames:        i.DNSNames,
 				DnsName:         i.DNSName,
 				IpAddresses:     ips,
 				Region:          i.region,


### PR DESCRIPTION
When the connector is configured with a DNS name, or if the Cloud SQL Instance reports that it has a DNS Name, 
the connector will use standard TLS hostname validation when checking the server certificate.  Now, the server's
TLS certificate must contain a SAN record with the instance's DNS name. 

The ConnectSettings API added a field `dns_names` which contains all of the valid DNS names for
an instance. 