### PR TITLE
chore: remove toolchain from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module cloud.google.com/go/cloudsqlconn
 
 go 1.23.0
 
-toolchain go1.23.7
-
 require (
 	cloud.google.com/go/auth v0.15.0
 	cloud.google.com/go/auth/oauth2adapt v0.2.7


### PR DESCRIPTION
Using the Go toolchain is really only needed when you support old versions of Go.

We only support active versions, same as the Go language does. 

Toolchain is thus not needed.