### PR TITLE
chore: update IP Type options in Test PG Auth

### DIFF
--- a/e2e_postgres_test.go
+++ b/e2e_postgres_test.go
@@ -738,8 +738,8 @@ func TestPostgresAuthentication(t *testing.T) {
 	var opts []cloudsqlconn.Option
 	if ipType != "private" {
 		creds = keyfile(t)
-		opts = AddIPTypeOptions(opts)
 	}
+	opts = AddIPTypeOptions(opts)
 	tok, path, cleanup := removeAuthEnvVar(t)
 	defer cleanup()
 


### PR DESCRIPTION
This PR updates call to AddIPTypeOptions function to correctly add PrivateIP option based on ipType

