### PR TITLE
chore: refactor AddIPTypeOptions function

### DIFF
--- a/e2e_postgres_test.go
+++ b/e2e_postgres_test.go
@@ -53,7 +53,7 @@ var (
 	postgresSANInvalidDomainName = os.Getenv("POSTGRES_CUSTOMER_CAS_INVALID_DOMAIN_NAME") // Cloud SQL Postgres CAS domain name that IS NOT an instance Custom SAN of the postgresSANConnName instance.
 )
 
-func AddIPTypeOptions(opts []cloudsqlconn.Option) []cloudsqlconn.Option {
+func addIPTypeOptions(opts []cloudsqlconn.Option) []cloudsqlconn.Option {
 	if ipType == "private" {
 		return append(opts, cloudsqlconn.WithDefaultDialOptions(cloudsqlconn.WithPrivateIP()))
 	}
@@ -110,7 +110,7 @@ func TestPostgresPgxPoolConnect(t *testing.T) {
 
 	// Use WithPrivateIP option if the ipType is set to private
 	var opts []cloudsqlconn.Option
-	opts = AddIPTypeOptions(opts)
+	opts = addIPTypeOptions(opts)
 
 	// Create a new dialer with any options
 	d, err := cloudsqlconn.NewDialer(ctx, opts...)
@@ -162,7 +162,7 @@ func TestPostgresCASConnect(t *testing.T) {
 
 	// Use WithPrivateIP option if the ipType is set to private
 	var opts []cloudsqlconn.Option
-	opts = AddIPTypeOptions(opts)
+	opts = addIPTypeOptions(opts)
 
 	// Create a new dialer with any options
 	d, err := cloudsqlconn.NewDialer(ctx, opts...)
@@ -214,7 +214,7 @@ func TestPostgresConnectWithQuotaProject(t *testing.T) {
 
 	// Use WithPrivateIP option if the ipType is set to private
 	var opts []cloudsqlconn.Option
-	opts = AddIPTypeOptions(opts)
+	opts = addIPTypeOptions(opts)
 
 	// Create a new dialer with any options
 	d, err := cloudsqlconn.NewDialer(ctx, append(opts, cloudsqlconn.WithQuotaProject(project))...)
@@ -266,7 +266,7 @@ func TestPostgresCustomerCASConnect(t *testing.T) {
 
 	// Use WithPrivateIP option if the ipType is set to private
 	var opts []cloudsqlconn.Option
-	opts = AddIPTypeOptions(opts)
+	opts = addIPTypeOptions(opts)
 
 	// Create a new dialer with any options
 	d, err := cloudsqlconn.NewDialer(ctx, opts...)
@@ -318,7 +318,7 @@ func TestPostgresMCPConnect(t *testing.T) {
 
 	// Use WithPrivateIP option if the ipType is set to private
 	var opts []cloudsqlconn.Option
-	opts = AddIPTypeOptions(opts)
+	opts = addIPTypeOptions(opts)
 
 	// Create a new dialer with any options
 	d, err := cloudsqlconn.NewDialer(ctx, opts...)
@@ -370,7 +370,7 @@ func TestPostgresSANDomainConnect(t *testing.T) {
 
 	// Use WithPrivateIP option if the ipType is set to private
 	var opts []cloudsqlconn.Option
-	opts = AddIPTypeOptions(opts)
+	opts = addIPTypeOptions(opts)
 
 	// Create a new dialer with any options
 	d, err := cloudsqlconn.NewDialer(ctx, append(opts, cloudsqlconn.WithDNSResolver())...)
@@ -423,7 +423,7 @@ func TestPostgresSANBadDomainCausesConnectError(t *testing.T) {
 
 	// Use WithPrivateIP option if the ipType is set to private
 	var opts []cloudsqlconn.Option
-	opts = AddIPTypeOptions(opts)
+	opts = addIPTypeOptions(opts)
 
 	// Create a new dialer with any options
 	d, err := cloudsqlconn.NewDialer(ctx, append(opts, cloudsqlconn.WithDNSResolver())...)
@@ -480,7 +480,7 @@ func TestPostgresPgxPoolConnectDomainName(t *testing.T) {
 
 	// Use WithPrivateIP option if the ipType is set to private
 	var opts []cloudsqlconn.Option
-	opts = AddIPTypeOptions(opts)
+	opts = addIPTypeOptions(opts)
 
 	// Create a new dialer with any options
 	d, err := cloudsqlconn.NewDialer(ctx, append(opts, cloudsqlconn.WithDNSResolver())...)
@@ -529,7 +529,7 @@ func TestPostgresConnectWithIAMUser(t *testing.T) {
 
 	// Use WithPrivateIP option if the ipType is set to private
 	var opts []cloudsqlconn.Option
-	opts = AddIPTypeOptions(opts)
+	opts = addIPTypeOptions(opts)
 
 	d, err := cloudsqlconn.NewDialer(ctx, append(opts, cloudsqlconn.WithIAMAuthN())...)
 	if err != nil {
@@ -572,7 +572,7 @@ func TestPostgresConnectWithLazyRefresh(t *testing.T) {
 
 	// Use WithPrivateIP option if the ipType is set to private
 	var opts []cloudsqlconn.Option
-	opts = AddIPTypeOptions(opts)
+	opts = addIPTypeOptions(opts)
 
 	d, err := cloudsqlconn.NewDialer(
 		ctx,
@@ -609,7 +609,7 @@ func TestPostgresEngineVersion(t *testing.T) {
 
 	// Use WithPrivateIP option if the ipType is set to private
 	var opts []cloudsqlconn.Option
-	opts = AddIPTypeOptions(opts)
+	opts = addIPTypeOptions(opts)
 
 	d, err := cloudsqlconn.NewDialer(context.Background(), opts...)
 	if err != nil {
@@ -628,7 +628,7 @@ func TestPostgresV5Hook(t *testing.T) {
 
 	// Use WithPrivateIP option if the ipType is set to private
 	var opts []cloudsqlconn.Option
-	opts = AddIPTypeOptions(opts)
+	opts = addIPTypeOptions(opts)
 
 	tests := []struct {
 		driver   string
@@ -696,7 +696,7 @@ func TestPostgresV4Hook(t *testing.T) {
 
 	// Use WithPrivateIP option if the ipType is set to private
 	var opts []cloudsqlconn.Option
-	opts = AddIPTypeOptions(opts)
+	opts = addIPTypeOptions(opts)
 
 	tests := []struct {
 		driver   string
@@ -797,7 +797,7 @@ func TestPostgresAuthentication(t *testing.T) {
 	if ipType != "private" {
 		creds = keyfile(t)
 	}
-	opts = AddIPTypeOptions(opts)
+	opts = addIPTypeOptions(opts)
 	tok, path, cleanup := removeAuthEnvVar(t)
 	defer cleanup()
 


### PR DESCRIPTION
This PR renames `AddIPTypeOptions` function to `addIPTypeOptions`, as it is an internal function