### PR TITLE
fix: fix logmessage for usage with domain names

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -350,7 +350,7 @@ func (d *Dialer) Dial(ctx context.Context, icn string, opts ...DialOption) (conn
 	// Log if resolver changed the instance name input string.
 	if cn.DomainName() != "" {
 		// icn is a domain name, which resolves to a actual icn
-		d.logger.Debugf(ctx, "resolved dns: %s", icn, cn.String())
+		d.logger.Debugf(ctx, "resolved domain name %s to %s", icn, cn.String())
 	} else if cn.String() != icn {
 		// icn was not a domain name, but the resolver changed it and cn != icn
 		d.logger.Debugf(ctx, "resolved instance connection string %s to %s", icn, cn.String())


### PR DESCRIPTION
issue: #936 

Instead of using the original string() method which contains the dns name. Update it to follow the standard icn name standard. 