### PR TITLE
ci: enable tests run for feature branch feature/client-side-metrics

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,6 +18,7 @@ on:
   push:
     branches:
       - main
+      - feature/client-side-metrics
   schedule:
     - cron: "0 2 * * *"
 


### PR DESCRIPTION
There will be ongoing PRs merging into feature branch `feature/client-side-metrics`. We need to ensure the feature branch is working as expected at all time. 