### PR TITLE
feat: dynamically detect client telemetry attributes and record dialstatus

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -395,25 +395,28 @@ func NewDialer(ctx context.Context, opts ...Option) (*Dialer, error) {
 }
 
 // metricRecorder does a lazy initialization of the metric exporter.
-func (d *Dialer) metricRecorder(ctx context.Context, inst instance.ConnName) tel.MetricRecorder {
+func (d *Dialer) metricRecorder(ctx context.Context, inst instance.ConnName, dbEngineType string) tel.MetricRecorder {
 	d.metricsMu.Lock()
 	defer d.metricsMu.Unlock()
 	if mr, ok := d.metricRecorders[inst]; ok {
-		return mr
+		if dbEngineType == "UNKNOWN" || dbEngineType == "" || mr.DatabaseEngine() == dbEngineType {
+			return mr
+		}
 	}
 	cfg := tel.Config{
 		Enabled:            !d.disableBuiltInMetrics,
 		Version:            versionString,
 		ResourceContainer:  inst.Project(),
-		ResourceID:         inst.Name(),
+		// ResourceID is the Cloud SQL instance identifier formatted as [project_name:instance_name].
+		ResourceID:         inst.Project() + ":" + inst.Name(),
 		ClientUID:          d.dialerID,
 		ApplicationName:    d.applicationName,
 		Region:             inst.Region(),
-		ClientRegion:       "Client-Region-Testing",    // TODO: detect client region
-		ComputePlatform:    "Compute-Platform-Testing", // TODO: detect compute platform
+		ClientRegion:       tel.DetectClientRegion(),
+		ComputePlatform:    tel.DetectComputePlatform(),
 		ConnectorType:      tel.ConnectorTypeValue(d.userAgent),
 		ConnectorVersion:   versionString,
-		DatabaseEngineType: "DB-Engine-Type-Testing", // TODO: detect database engine type
+		DatabaseEngineType: dbEngineType,
 	}
 	mr := tel.NewMetricRecorder(ctx, d.logger, d.mClient, cfg)
 	d.metricRecorders[inst] = mr
@@ -441,7 +444,7 @@ func (d *Dialer) Dial(ctx context.Context, icn string, opts ...DialOption) (conn
 	if err != nil {
 		return nil, err
 	}
-	mr := d.metricRecorder(ctx, cn)
+	mr := d.metricRecorder(ctx, cn, "UNKNOWN")
 
 	startTime := time.Now()
 	var endDial trace.EndSpanFunc
@@ -535,16 +538,21 @@ func (d *Dialer) connectInstanceIP(ctx context.Context, cn instance.ConnName, cf
 	c, cacheHit, err := d.connectionInfoCache(ctx, cn, &cfg.useIAMAuthN)
 	attrs.CacheHit = cacheHit
 	if err != nil {
+		attrs.DialStatus = tel.ConnectError
+		mr.RecordConnectLatencies(ctx, attrs, time.Since(startTime).Milliseconds())
 		endInfo(err)
 		return nil, err
 	}
 	ci, err := c.ConnectionInfo(ctx)
 	if err != nil {
 		d.removeCached(ctx, cn, c, err)
+		attrs.DialStatus = tel.ConnectError
+		mr.RecordConnectLatencies(ctx, attrs, time.Since(startTime).Milliseconds())
 		endInfo(err)
 		return nil, err
 	}
-	endInfo(err)
+	mr = d.metricRecorder(ctx, cn, tel.DetectDatabaseEngineType(ci.DBVersion))
+	endInfo(nil)
 
 	// If the client certificate has expired (as when the computer goes to
 	// sleep, and the refresh cycle cannot run), force a refresh immediately.
@@ -604,6 +612,8 @@ func (d *Dialer) connectInstanceIP(ctx context.Context, cn instance.ConnName, cf
 		d.logger.Debugf(ctx, "[%v] Dialing %v failed: %v", cn.String(), addr, err)
 		// refresh the instance info in case it caused the connection failure
 		c.ForceRefresh()
+		attrs.DialStatus = tel.ConnectError
+		mr.RecordConnectLatencies(ctx, attrs, time.Since(startTime).Milliseconds())
 		return nil, errtype.NewDialError("failed to dial", cn.String(), err)
 	}
 	if c, ok := conn.(*net.TCPConn); ok {
@@ -624,6 +634,8 @@ func (d *Dialer) connectInstanceIP(ctx context.Context, cn instance.ConnName, cf
 		d.logger.Debugf(ctx, "[%v] TLS handshake failed: %v", cn.String(), err)
 		d.removeCached(ctx, cn, c, err)
 		_ = tlsConn.Close() // best effort close attempt
+		attrs.DialStatus = tel.ConnectError
+		mr.RecordConnectLatencies(ctx, attrs, time.Since(startTime).Milliseconds())
 		return nil, errtype.NewDialError("handshake failed", cn.String(), err)
 	}
 
@@ -639,6 +651,7 @@ func (d *Dialer) connectInstanceIP(ctx context.Context, cn instance.ConnName, cf
 	n := c.openConnsCount.Add(1)
 	trace.RecordOpenConnections(ctx, int64(n), d.dialerID, cn.String())
 	trace.RecordDialLatency(ctx, cn.String(), d.dialerID, latency)
+	attrs.DialStatus = tel.ConnectSuccess
 	mr.RecordOpenConnection(ctx, attrs)
 	mr.RecordConnectLatencies(ctx, attrs, latency)
 
@@ -647,8 +660,6 @@ func (d *Dialer) connectInstanceIP(ctx context.Context, cn instance.ConnName, cf
 		trace.RecordOpenConnections(context.Background(), int64(n), d.dialerID, cn.String())
 		mr.RecordClosedConnection(context.Background(), attrs)
 		mr.RecordClosedConnectionCount(context.Background(), attrs)
-		// lot the message to terminal for debugging purposes
-		fmt.Println("Cloud SQL Go Connector Dialer ID:", d.dialerID, "closed connection to instance:", cn.String())
 	}
 	errFunc := func(err error) {
 		// io.EOF occurs when the server closes the connection. This is safe to

--- a/dialer.go
+++ b/dialer.go
@@ -404,9 +404,9 @@ func (d *Dialer) metricRecorder(ctx context.Context, inst instance.ConnName, dbE
 		}
 	}
 	cfg := tel.Config{
-		Enabled:            !d.disableBuiltInMetrics,
-		Version:            versionString,
-		ResourceContainer:  inst.Project(),
+		Enabled:           !d.disableBuiltInMetrics,
+		Version:           versionString,
+		ResourceContainer: inst.Project(),
 		// ResourceID is the Cloud SQL instance identifier formatted as [project_name:instance_name].
 		ResourceID:         inst.Project() + ":" + inst.Name(),
 		ClientUID:          d.dialerID,

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.8
 require (
 	cloud.google.com/go/auth v0.20.0
 	cloud.google.com/go/auth/oauth2adapt v0.2.8
+	cloud.google.com/go/compute/metadata v0.9.0
 	cloud.google.com/go/monitoring v1.24.3
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.54.0
 	github.com/go-sql-driver/mysql v1.10.0
@@ -27,7 +28,6 @@ require (
 )
 
 require (
-	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/internal/tel/tel.go
+++ b/internal/tel/tel.go
@@ -129,27 +129,22 @@ func DetectClientRegion() (region string) {
 			region = "UNKNOWN"
 		}
 	}()
-	if metadata.OnGCE() {
-		zone, err := metadata.Zone()
-		if err == nil && zone != "" {
-			if idx := strings.LastIndex(zone, "-"); idx != -1 {
-				return zone[:idx]
-			}
-			return zone
-		}
+	if !metadata.OnGCE() {
+		return "UNKNOWN"
 	}
-	return "UNKNOWN"
+	zone, err := metadata.Zone()
+	if err != nil || zone == "" {
+		return "UNKNOWN"
+	}
+	if idx := strings.LastIndex(zone, "-"); idx != -1 {
+		return zone[:idx]
+	}
+	return zone
 }
 
 // DetectComputePlatform detects the GCP compute platform environment.
 // Any panic or error fails silently and returns "UNKNOWN".
 func DetectComputePlatform() (platform string) {
-	// Safeguard against unexpected panics to prevent hard crashes in client applications.
-	defer func() {
-		if r := recover(); r != nil {
-			platform = "UNKNOWN"
-		}
-	}()
 	switch {
 	case os.Getenv("KUBERNETES_SERVICE_HOST") != "":
 		return "GKE"
@@ -169,12 +164,6 @@ func DetectComputePlatform() (platform string) {
 // DetectDatabaseEngineType detects the database engine type from a Cloud SQL DBVersion string.
 // Any panic or error fails silently and returns "UNKNOWN".
 func DetectDatabaseEngineType(dbVersion string) (engine string) {
-	// Safeguard against unexpected panics to prevent hard crashes in client applications.
-	defer func() {
-		if r := recover(); r != nil {
-			engine = "UNKNOWN"
-		}
-	}()
 	switch {
 	case strings.HasPrefix(dbVersion, "MYSQL"):
 		return "MYSQL"

--- a/internal/tel/tel.go
+++ b/internal/tel/tel.go
@@ -16,8 +16,11 @@ package tel
 
 import (
 	"context"
+	"os"
 	"strings"
 	"time"
+
+	"cloud.google.com/go/compute/metadata"
 
 	"cloud.google.com/go/cloudsqlconn/debug"
 	"go.opentelemetry.io/otel/attribute"
@@ -117,6 +120,73 @@ func AuthTypeValue(iamAuthn bool) string {
 	return "built_in"
 }
 
+// DetectClientRegion returns the client region from GCP metadata if running on GCE/GKE/Cloud Run.
+// Any panic or error fails silently and returns "UNKNOWN".
+func DetectClientRegion() (region string) {
+	// Safeguard against unexpected panics to prevent hard crashes in client applications.
+	defer func() {
+		if r := recover(); r != nil {
+			region = "UNKNOWN"
+		}
+	}()
+	if metadata.OnGCE() {
+		zone, err := metadata.Zone()
+		if err == nil && zone != "" {
+			if idx := strings.LastIndex(zone, "-"); idx != -1 {
+				return zone[:idx]
+			}
+			return zone
+		}
+	}
+	return "UNKNOWN"
+}
+
+// DetectComputePlatform detects the GCP compute platform environment.
+// Any panic or error fails silently and returns "UNKNOWN".
+func DetectComputePlatform() (platform string) {
+	// Safeguard against unexpected panics to prevent hard crashes in client applications.
+	defer func() {
+		if r := recover(); r != nil {
+			platform = "UNKNOWN"
+		}
+	}()
+	switch {
+	case os.Getenv("KUBERNETES_SERVICE_HOST") != "":
+		return "GKE"
+	case os.Getenv("K_SERVICE") != "":
+		return "CLOUD_RUN"
+	case os.Getenv("GAE_SERVICE") != "":
+		return "APP_ENGINE"
+	case os.Getenv("FUNCTION_NAME") != "":
+		return "CLOUD_FUNCTIONS"
+	case metadata.OnGCE():
+		return "GCE"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// DetectDatabaseEngineType detects the database engine type from a Cloud SQL DBVersion string.
+// Any panic or error fails silently and returns "UNKNOWN".
+func DetectDatabaseEngineType(dbVersion string) (engine string) {
+	// Safeguard against unexpected panics to prevent hard crashes in client applications.
+	defer func() {
+		if r := recover(); r != nil {
+			engine = "UNKNOWN"
+		}
+	}()
+	switch {
+	case strings.HasPrefix(dbVersion, "MYSQL"):
+		return "MYSQL"
+	case strings.HasPrefix(dbVersion, "POSTGRES"):
+		return "POSTGRESQL"
+	case strings.HasPrefix(dbVersion, "SQLSERVER"):
+		return "SQLSERVER"
+	default:
+		return "UNKNOWN"
+	}
+}
+
 // Attributes holds all the various pieces of metadata to attach to a metric.
 type Attributes struct {
 	// IAMAuthN specifies whether IAM authentication is enabled.
@@ -141,6 +211,7 @@ type MetricRecorder interface {
 	RecordClosedConnection(context.Context, Attributes)
 	RecordClosedConnectionCount(context.Context, Attributes)
 	RecordConnectLatencies(context.Context, Attributes, int64)
+	DatabaseEngine() string
 }
 
 // DefaultExportInterval is the interval that the metric exporter runs. It
@@ -226,6 +297,7 @@ func NewMetricRecorder(ctx context.Context, l debug.ContextLogger, cl *monitorin
 		exporter:               exp,
 		provider:               p,
 		dialerID:               cfg.ClientUID,
+		dbEngineType:           cfg.DatabaseEngineType,
 		mClosedConnectionCount: mClosedConnectionCount,
 		mConnectLatency:        mConnectLatency,
 		mOpenConns:             mOpenConns,
@@ -237,9 +309,15 @@ type metricRecorder struct {
 	exporter               sdkmetric.Exporter
 	provider               *sdkmetric.MeterProvider
 	dialerID               string
+	dbEngineType           string
 	mClosedConnectionCount metric.Int64Counter
 	mConnectLatency        metric.Float64Histogram
 	mOpenConns             metric.Int64UpDownCounter
+}
+
+// DatabaseEngine returns the configured database engine type for this recorder.
+func (m *metricRecorder) DatabaseEngine() string {
+	return m.dbEngineType
 }
 
 // RecordClosedConnectionCount records totals number of closed connections.
@@ -261,7 +339,7 @@ func (m *metricRecorder) RecordOpenConnection(ctx context.Context, a Attributes)
 		)))
 }
 
-// RecordOpenConnection records current number of open connections.
+// RecordClosedConnection decreases current number of open connections.
 func (m *metricRecorder) RecordClosedConnection(ctx context.Context, a Attributes) {
 	m.mOpenConns.Add(ctx, -1,
 		metric.WithAttributeSet(attribute.NewSet(
@@ -295,4 +373,9 @@ func (n NullMetricRecorder) RecordClosedConnectionCount(context.Context, Attribu
 
 // RecordConnectLatencies is a no-op.
 func (n NullMetricRecorder) RecordConnectLatencies(context.Context, Attributes, int64) {
+}
+
+// DatabaseEngine returns an empty string for the null recorder.
+func (n NullMetricRecorder) DatabaseEngine() string {
+	return ""
 }

--- a/internal/tel/tel_test.go
+++ b/internal/tel/tel_test.go
@@ -309,3 +309,29 @@ func TestMetricRecorder(t *testing.T) {
 	}
 
 }
+
+func TestDetectDatabaseEngineType(t *testing.T) {
+	tests := []struct {
+		dbVersion string
+		want      string
+	}{
+		{"MYSQL_8_0", "MYSQL"},
+		{"POSTGRES_15", "POSTGRESQL"},
+		{"SQLSERVER_2019_STANDARD", "SQLSERVER"},
+		{"UNKNOWN_DB", "UNKNOWN"},
+		{"", "UNKNOWN"},
+	}
+	for _, tc := range tests {
+		got := tel.DetectDatabaseEngineType(tc.dbVersion)
+		if got != tc.want {
+			t.Errorf("DetectDatabaseEngineType(%q) = %q, want %q", tc.dbVersion, got, tc.want)
+		}
+	}
+}
+
+func TestDetectComputePlatform(t *testing.T) {
+	t.Setenv("K_SERVICE", "my-cloud-run-svc")
+	if got := tel.DetectComputePlatform(); got != "CLOUD_RUN" {
+		t.Errorf("DetectComputePlatform() = %q, want %q", got, "CLOUD_RUN")
+	}
+}


### PR DESCRIPTION
Continue the initial setup of the client metric. 

- Dynamically detect ClientRegion, ComputePlatform, and DatabaseEngineType in telemetry Config
- Format ResourceID as [project_name:instance_name]
- Upgrade cached MetricRecorder engine type once connection info DBVersion is retrieved
- Protect detection helper functions with panic recovery safeguards