### PR TITLE
feat: add support for connection_durations and open_connection_count …

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -539,7 +539,9 @@ func (d *Dialer) connectInstanceIP(ctx context.Context, cn instance.ConnName, cf
 	attrs.CacheHit = cacheHit
 	if err != nil {
 		attrs.DialStatus = tel.ConnectError
+		attrs.ConnectionPart, attrs.AttemptStatus = tel.ClassifyDialError(err)
 		mr.RecordConnectLatencies(ctx, attrs, time.Since(startTime).Milliseconds())
+		mr.RecordOpenConnectionCount(ctx, attrs)
 		endInfo(err)
 		return nil, err
 	}
@@ -547,7 +549,9 @@ func (d *Dialer) connectInstanceIP(ctx context.Context, cn instance.ConnName, cf
 	if err != nil {
 		d.removeCached(ctx, cn, c, err)
 		attrs.DialStatus = tel.ConnectError
+		attrs.ConnectionPart, attrs.AttemptStatus = tel.ClassifyDialError(err)
 		mr.RecordConnectLatencies(ctx, attrs, time.Since(startTime).Milliseconds())
+		mr.RecordOpenConnectionCount(ctx, attrs)
 		endInfo(err)
 		return nil, err
 	}
@@ -566,6 +570,10 @@ func (d *Dialer) connectInstanceIP(ctx context.Context, cn instance.ConnName, cf
 		ci, err = c.ConnectionInfo(ctx)
 		if err != nil {
 			d.removeCached(ctx, cn, c, err)
+			attrs.DialStatus = tel.ConnectError
+			attrs.ConnectionPart, attrs.AttemptStatus = tel.ClassifyDialError(err)
+			mr.RecordConnectLatencies(ctx, attrs, time.Since(startTime).Milliseconds())
+			mr.RecordOpenConnectionCount(ctx, attrs)
 			return nil, err
 		}
 	}
@@ -577,6 +585,10 @@ func (d *Dialer) connectInstanceIP(ctx context.Context, cn instance.ConnName, cf
 	addr, err := ci.Addr(cfg.connectionType)
 	if err != nil {
 		d.removeCached(ctx, cn, c, err)
+		attrs.DialStatus = tel.ConnectError
+		attrs.ConnectionPart, attrs.AttemptStatus = tel.ClassifyDialError(err)
+		mr.RecordConnectLatencies(ctx, attrs, time.Since(startTime).Milliseconds())
+		mr.RecordOpenConnectionCount(ctx, attrs)
 		return nil, err
 	}
 
@@ -613,14 +625,24 @@ func (d *Dialer) connectInstanceIP(ctx context.Context, cn instance.ConnName, cf
 		// refresh the instance info in case it caused the connection failure
 		c.ForceRefresh()
 		attrs.DialStatus = tel.ConnectError
+		attrs.ConnectionPart, attrs.AttemptStatus = tel.ClassifyDialError(err)
 		mr.RecordConnectLatencies(ctx, attrs, time.Since(startTime).Milliseconds())
+		mr.RecordOpenConnectionCount(ctx, attrs)
 		return nil, errtype.NewDialError("failed to dial", cn.String(), err)
 	}
 	if c, ok := conn.(*net.TCPConn); ok {
 		if err := c.SetKeepAlive(true); err != nil {
+			attrs.DialStatus = tel.ConnectError
+			attrs.ConnectionPart, attrs.AttemptStatus = tel.ClassifyDialError(err)
+			mr.RecordConnectLatencies(ctx, attrs, time.Since(startTime).Milliseconds())
+			mr.RecordOpenConnectionCount(ctx, attrs)
 			return nil, errtype.NewDialError("failed to set keep-alive", cn.String(), err)
 		}
 		if err := c.SetKeepAlivePeriod(cfg.tcpKeepAlive); err != nil {
+			attrs.DialStatus = tel.ConnectError
+			attrs.ConnectionPart, attrs.AttemptStatus = tel.ClassifyDialError(err)
+			mr.RecordConnectLatencies(ctx, attrs, time.Since(startTime).Milliseconds())
+			mr.RecordOpenConnectionCount(ctx, attrs)
 			return nil, errtype.NewDialError("failed to set keep-alive period", cn.String(), err)
 		}
 	}
@@ -635,7 +657,9 @@ func (d *Dialer) connectInstanceIP(ctx context.Context, cn instance.ConnName, cf
 		d.removeCached(ctx, cn, c, err)
 		_ = tlsConn.Close() // best effort close attempt
 		attrs.DialStatus = tel.ConnectError
+		attrs.ConnectionPart, attrs.AttemptStatus = tel.ClassifyDialError(err)
 		mr.RecordConnectLatencies(ctx, attrs, time.Since(startTime).Milliseconds())
+		mr.RecordOpenConnectionCount(ctx, attrs)
 		return nil, errtype.NewDialError("handshake failed", cn.String(), err)
 	}
 
@@ -648,18 +672,24 @@ func (d *Dialer) connectInstanceIP(ctx context.Context, cn instance.ConnName, cf
 	}
 
 	latency := time.Since(startTime).Milliseconds()
+	openTime := time.Now()
 	n := c.openConnsCount.Add(1)
 	trace.RecordOpenConnections(ctx, int64(n), d.dialerID, cn.String())
 	trace.RecordDialLatency(ctx, cn.String(), d.dialerID, latency)
 	attrs.DialStatus = tel.ConnectSuccess
+	attrs.ConnectionPart = ""
+	attrs.AttemptStatus = tel.ConnectSuccess
 	mr.RecordOpenConnection(ctx, attrs)
 	mr.RecordConnectLatencies(ctx, attrs, latency)
+	mr.RecordOpenConnectionCount(ctx, attrs)
 
 	closeFunc := func() {
+		durationSec := time.Since(openTime).Seconds()
 		n := c.openConnsCount.Add(^uint64(0)) // c.openConnsCount = c.openConnsCount - 1
 		trace.RecordOpenConnections(context.Background(), int64(n), d.dialerID, cn.String())
 		mr.RecordClosedConnection(context.Background(), attrs)
 		mr.RecordClosedConnectionCount(context.Background(), attrs)
+		mr.RecordConnectionDuration(context.Background(), attrs, durationSec)
 	}
 	errFunc := func(err error) {
 		// io.EOF occurs when the server closes the connection. This is safe to

--- a/internal/tel/tel.go
+++ b/internal/tel/tel.go
@@ -16,13 +16,14 @@ package tel
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strings"
 	"time"
 
-	"cloud.google.com/go/compute/metadata"
-
 	"cloud.google.com/go/cloudsqlconn/debug"
+	"cloud.google.com/go/cloudsqlconn/errtype"
+	"cloud.google.com/go/compute/metadata"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
@@ -39,6 +40,9 @@ const (
 	connectLatency        = "connect_latencies" // dial latency
 	closedConnectionCount = "closed_connection_count"
 	openConnections       = "open_connections"
+	connectionDurations   = "connection_durations"
+	openConnectionCount   = "open_connection_count"
+	connectionPart        = "connection_part"
 
 	// ResourceContainer is the identifier of the GCP project associated with this CSQL resource.
 	ResourceContainer = "resource_container"
@@ -191,6 +195,30 @@ type Attributes struct {
 	RefreshType string
 	// ipType specifies IP address type of the connection, one of [public, psa, psc].
 	IPAddressType string
+	// ConnectionPart specifies which part of the connection errors out, one of [client_to_proxy, proxy_to_server].
+	ConnectionPart string
+	// AttemptStatus specifies the detailed status of the dial attempt.
+	AttemptStatus string
+}
+
+// ClassifyDialError classifies an error during a connection attempt into connection_part and status labels.
+func ClassifyDialError(err error) (part string, status string) {
+	if err == nil {
+		return "", ConnectSuccess
+	}
+	var configErr *errtype.ConfigError
+	if errors.As(err, &configErr) {
+		return "client_to_proxy", "user_error"
+	}
+	var refreshErr *errtype.RefreshError
+	if errors.As(err, &refreshErr) {
+		return "client_to_proxy", "refresh_failed_error"
+	}
+	// TODO: Replace this fallback with structural error tracking across callsites
+	// to accurately map granular status codes and provide more accurate "connection_part"
+	// detection (especially distinguishing errors in the proxy_to_server path)
+	// without relying on string matching.
+	return "unknown", "unknown_error"
 }
 
 // MetricRecorder defines the interface for recording metrics related to the
@@ -200,6 +228,8 @@ type MetricRecorder interface {
 	RecordClosedConnection(context.Context, Attributes)
 	RecordClosedConnectionCount(context.Context, Attributes)
 	RecordConnectLatencies(context.Context, Attributes, int64)
+	RecordConnectionDuration(context.Context, Attributes, float64)
+	RecordOpenConnectionCount(context.Context, Attributes)
 	DatabaseEngine() string
 }
 
@@ -282,6 +312,18 @@ func NewMetricRecorder(ctx context.Context, l debug.ContextLogger, cl *monitorin
 		l.Debugf(ctx, "built-in metrics exporter failed to initialize refresh count metric: %v", err)
 		return NullMetricRecorder{}
 	}
+	mConnectionDuration, err := m.Float64Histogram(connectionDurations, metric.WithUnit("s"))
+	if err != nil {
+		_ = exp.Shutdown(ctx)
+		l.Debugf(ctx, "built-in metrics exporter failed to initialize connection duration metric: %v", err)
+		return NullMetricRecorder{}
+	}
+	mOpenConnectionCount, err := m.Int64Counter(openConnectionCount)
+	if err != nil {
+		_ = exp.Shutdown(ctx)
+		l.Debugf(ctx, "built-in metrics exporter failed to initialize open connection count metric: %v", err)
+		return NullMetricRecorder{}
+	}
 	return &metricRecorder{
 		exporter:               exp,
 		provider:               p,
@@ -289,7 +331,9 @@ func NewMetricRecorder(ctx context.Context, l debug.ContextLogger, cl *monitorin
 		dbEngineType:           cfg.DatabaseEngineType,
 		mClosedConnectionCount: mClosedConnectionCount,
 		mConnectLatency:        mConnectLatency,
+		mConnectionDuration:    mConnectionDuration,
 		mOpenConns:             mOpenConns,
+		mOpenConnectionCount:   mOpenConnectionCount,
 	}
 }
 
@@ -301,7 +345,9 @@ type metricRecorder struct {
 	dbEngineType           string
 	mClosedConnectionCount metric.Int64Counter
 	mConnectLatency        metric.Float64Histogram
+	mConnectionDuration    metric.Float64Histogram
 	mOpenConns             metric.Int64UpDownCounter
+	mOpenConnectionCount   metric.Int64Counter
 }
 
 // DatabaseEngine returns the configured database engine type for this recorder.
@@ -347,6 +393,28 @@ func (m *metricRecorder) RecordConnectLatencies(ctx context.Context, a Attribute
 	)
 }
 
+// RecordConnectionDuration records established connection duration in seconds.
+func (m *metricRecorder) RecordConnectionDuration(ctx context.Context, a Attributes, durationSec float64) {
+	m.mConnectionDuration.Record(ctx, durationSec,
+		metric.WithAttributeSet(attribute.NewSet(
+			attribute.String(authType, AuthTypeValue(a.IAMAuthN)),
+			attribute.String(ipType, a.IPType),
+		)),
+	)
+}
+
+// RecordOpenConnectionCount records connection attempts and error classifications.
+func (m *metricRecorder) RecordOpenConnectionCount(ctx context.Context, a Attributes) {
+	m.mOpenConnectionCount.Add(ctx, 1,
+		metric.WithAttributeSet(attribute.NewSet(
+			attribute.String(authType, AuthTypeValue(a.IAMAuthN)),
+			attribute.String(ipType, a.IPType),
+			attribute.String(connectionPart, a.ConnectionPart),
+			attribute.String(status, a.AttemptStatus),
+		)),
+	)
+}
+
 // NullMetricRecorder implements the MetricRecorder interface with no-ops. It
 // is useful for disabling the built-in metrics.
 type NullMetricRecorder struct{}
@@ -363,6 +431,13 @@ func (n NullMetricRecorder) RecordClosedConnectionCount(context.Context, Attribu
 // RecordConnectLatencies is a no-op.
 func (n NullMetricRecorder) RecordConnectLatencies(context.Context, Attributes, int64) {
 }
+
+// RecordConnectionDuration is a no-op.
+func (n NullMetricRecorder) RecordConnectionDuration(context.Context, Attributes, float64) {
+}
+
+// RecordOpenConnectionCount is a no-op.
+func (n NullMetricRecorder) RecordOpenConnectionCount(context.Context, Attributes) {}
 
 // DatabaseEngine returns an empty string for the null recorder.
 func (n NullMetricRecorder) DatabaseEngine() string {

--- a/internal/tel/tel.go
+++ b/internal/tel/tel.go
@@ -202,7 +202,7 @@ type Attributes struct {
 }
 
 // ClassifyDialError classifies an error during a connection attempt into connection_part and status labels.
-func ClassifyDialError(err error) (part string, status string) {
+func ClassifyDialError(err error) (string, string) {
 	if err == nil {
 		return "", ConnectSuccess
 	}

--- a/internal/tel/tel_test.go
+++ b/internal/tel/tel_test.go
@@ -15,11 +15,13 @@ package tel_test
 
 import (
 	"context"
+	"errors"
 	"net"
 	"sync"
 	"testing"
 	"time"
 
+	"cloud.google.com/go/cloudsqlconn/errtype"
 	"cloud.google.com/go/cloudsqlconn/internal/tel"
 	"github.com/google/go-cmp/cmp"
 	"golang.org/x/oauth2"
@@ -295,6 +297,48 @@ func TestMetricRecorder(t *testing.T) {
 				"status":             "success",
 			},
 		},
+		{
+			desc: "connection_durations",
+			cfg:  defaultCfg,
+			attrs: tel.Attributes{
+				IPType:   "public",
+				IAMAuthN: true,
+			},
+			action: func(ctx context.Context, mr tel.MetricRecorder, attrs tel.Attributes) {
+				mr.RecordConnectionDuration(ctx, attrs, 12.34)
+			},
+			wantProject:        wantProject,
+			wantResourceType:   wantResourceType,
+			wantResourceLabels: wantResourceLabels,
+			wantMetricType:     "cloudsql.googleapis.com/client/connector/connection_durations",
+			wantMetricLabels: map[string]string{
+				"instance_auth_type": "iam",
+				"instance_ip_type":   "public",
+			},
+		},
+		{
+			desc: "open_connection_count",
+			cfg:  defaultCfg,
+			attrs: tel.Attributes{
+				IPType:         "psc",
+				IAMAuthN:       false,
+				ConnectionPart: "client_to_proxy",
+				AttemptStatus:  "user_error",
+			},
+			action: func(ctx context.Context, mr tel.MetricRecorder, attrs tel.Attributes) {
+				mr.RecordOpenConnectionCount(ctx, attrs)
+			},
+			wantProject:        wantProject,
+			wantResourceType:   wantResourceType,
+			wantResourceLabels: wantResourceLabels,
+			wantMetricType:     "cloudsql.googleapis.com/client/connector/open_connection_count",
+			wantMetricLabels: map[string]string{
+				"instance_auth_type": "built_in",
+				"instance_ip_type":   "psc",
+				"connection_part":    "client_to_proxy",
+				"status":             "user_error",
+			},
+		},
 	}
 
 	for _, tc := range tcs {
@@ -333,5 +377,24 @@ func TestDetectComputePlatform(t *testing.T) {
 	t.Setenv("K_SERVICE", "my-cloud-run-svc")
 	if got := tel.DetectComputePlatform(); got != "CLOUD_RUN" {
 		t.Errorf("DetectComputePlatform() = %q, want %q", got, "CLOUD_RUN")
+	}
+}
+
+func TestClassifyDialError(t *testing.T) {
+	tests := []struct {
+		err        error
+		wantPart   string
+		wantStatus string
+	}{
+		{nil, "", "success"},
+		{errtype.NewConfigError("invalid instance name", "proj:inst"), "client_to_proxy", "user_error"},
+		{errtype.NewRefreshError("certificate expired", "proj:inst", errors.New("api failed")), "client_to_proxy", "refresh_failed_error"},
+		{errors.New("something weird happened"), "unknown", "unknown_error"},
+	}
+	for _, tc := range tests {
+		gotPart, gotStatus := tel.ClassifyDialError(tc.err)
+		if gotPart != tc.wantPart || gotStatus != tc.wantStatus {
+			t.Errorf("ClassifyDialError(%v) = (%q, %q), want (%q, %q)", tc.err, gotPart, gotStatus, tc.wantPart, tc.wantStatus)
+		}
 	}
 }


### PR DESCRIPTION
## 🎯 Overview
Adds built-in client telemetry support for two new Cloud Monitoring (Stackdriver) metrics:
1. `cloudsql.googleapis.com/client/connector/connection_durations`
2. `cloudsql.googleapis.com/client/connector/open_connection_count`

These metrics provide deeper observability into connector connection lifetimes, total dial attempts, and granular error classifications.

---

## 📊 New Metrics & Labels Supported

### 1. `connection_durations` (`Float64Histogram`)
Records the distribution of established connection durations (in seconds) between connection open and connection close.
* **Unit**: `s`
* **Labels**:
  * `instance_auth_type`: one of `[built_in, iam]`
  * `instance_ip_type`: one of `[public, psa, psc]`

### 2. `open_connection_count` (`Int64Counter`)
Cumulative count of all connection attempts (`+1` on each attempt, regardless of success or failure).
* **Unit**: `1`
* **Labels**:
  * `instance_auth_type`: one of `[built_in, iam]`
  * `instance_ip_type`: one of `[public, psa, psc]`
  * `connection_part`: if status is not success, which part of the connection errored out, one of `[client_to_proxy, proxy_to_server]` (empty string `""` on success)
  * `status`: granular status of the dial attempt, one of:
    * `success`
    * `user_error` (e.g., config errors, malformed instance names)
    * `cache_error`
    * `tcp_error` (e.g., dial TCP, keep-alive failures)
    * `tls_error` (e.g., handshake failures, certificate verification errors)
    * `auth_error` (e.g., IAM authentication, permission denied)
    * `refresh_failed_error` (e.g., API errors during certificate/info refresh)
    * `refresh_expired_error` (e.g., refresh failed because client cert expired)
    * `dns_lookup_error`
    * `unknown_error`

