### PR TITLE
fix: Correctly identify unsupported instance edition error.

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -602,7 +602,7 @@ func (d *Dialer) connectInstanceIP(ctx context.Context, cn instance.ConnName, cf
 func isSQLDataUnsupportedError(err error) bool {
 	if s, ok := status.FromError(err); ok {
 		return s.Code() == codes.FailedPrecondition &&
-			strings.HasPrefix(s.Message(), "unsupported instance edition:")
+			strings.HasPrefix(s.Message(), "unsupported instance edition")
 	}
 	return false
 }


### PR DESCRIPTION
Removed extraneous `:` character from the test for the error message.