### PR TITLE
chore: Open the mock server on port 3307 with retries.

### DIFF
--- a/internal/mock/cloudsql.go
+++ b/internal/mock/cloudsql.go
@@ -299,8 +299,7 @@ func GenerateCertWithCommonName(i FakeCSQLInstance, cn string) []byte {
 // on all interfaces, configured with TLS as specified by the FakeCSQLInstance.
 // Callers should invoke the returned function to clean up all resources.
 func StartServerProxy(t *testing.T, i FakeCSQLInstance) func() {
-
-	ln, err := tls.Listen("tcp", ":3307", &tls.Config{
+	ln, err := startListenerWithRetries(&tls.Config{
 		Certificates: i.certs.serverChain(i.useStandardTLSValidation),
 		ClientCAs:    i.certs.clientCAPool(),
 		ClientAuth:   tls.RequireAndVerifyClientCert,
@@ -368,6 +367,22 @@ func StartServerProxy(t *testing.T, i FakeCSQLInstance) func() {
 	}
 }
 
+// startListenerWithRetries opens a mock server on port 3307 for testing. If it fails
+// to open the port, it waits and retries up to 50 times. This prevents test flakes caused
+// by delays cleaning up the mock server from prior tests.
+func startListenerWithRetries(cfg *tls.Config) (net.Listener, error) {
+	var ln net.Listener
+	var err error
+	for attempts := 0; attempts < 50; attempts++ {
+		ln, err = tls.Listen("tcp", ":3307", cfg)
+		if err == nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return ln, err
+}
+
 // RotateCA rotates all CA certificates and keys.
 func RotateCA(inst FakeCSQLInstance) {
 	inst.certs.rotateCA()
@@ -409,8 +424,7 @@ func NewFailoverTestServer(t *testing.T) *FailoverTestServer {
 
 // Start starts the test server up, to make sure that it is ready to go
 func (s *FailoverTestServer) Start(i *FakeCSQLInstance) {
-
-	ln, err := tls.Listen("tcp", ":3307", &tls.Config{
+	ln, err := startListenerWithRetries(&tls.Config{
 		Certificates: i.certs.serverChain(i.useStandardTLSValidation),
 		ClientCAs:    i.certs.clientCAPool(),
 		ClientAuth:   tls.RequireAndVerifyClientCert,


### PR DESCRIPTION
This is a mock server used in unit tests. It listens on port 3307. Sometimes one test will close the socket, but the OS won't clean it up and make it available in time, and the next test fails. This change allows the next test to retry opening the server socket.