### PR TITLE
fix: use generated XML in integration tests workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -123,7 +123,7 @@ jobs:
           ./build.sh e2e_ci
 
       - name: Convert test output to XML
-        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'pull_request') && always() }}
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && always() }}
         run: |
           cp test-results/e2e.xml integration_sponge_log.xml
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -123,10 +123,9 @@ jobs:
           ./build.sh e2e_ci
 
       - name: Convert test output to XML
-        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && always() }}
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'pull_request') && always() }}
         run: |
-          go install github.com/jstemmer/go-junit-report/v2@latest
-          go-junit-report -in test_results.txt -set-exit-code -out integration_sponge_log.xml
+          cp test-results/e2e.xml integration_sponge_log.xml
 
       - name: FlakyBot (Linux)
         # only run flakybot on periodic (schedule) and continuous (push) events


### PR DESCRIPTION
This PR fixes the failing integration tests workflow. The Convert test output to XML step was failing because it was looking for test_results.txt which is no longer generated by build.sh e2e_ci. We now copy test-results/e2e.xml (generated by build.sh) to integration_sponge_log.xml. I have also temporarily enabled this step on pull_request events to verify it runs correctly on all runners.