### PR TITLE
fix: handle GitHub API rate limiting in build script and workflows

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,6 +34,8 @@ jobs:
         with:
           go-version: "1.26"
       - name: lint
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./build.sh lint_ci
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -92,6 +92,7 @@ jobs:
 
       - name: Run tests
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MYSQL_CONNECTION_NAME: "${{ steps.secrets.outputs.MYSQL_CONNECTION_NAME }}"
           MYSQL_USER: "${{ steps.secrets.outputs.MYSQL_USER }}"
           MYSQL_USER_IAM: "${{ steps.secrets.outputs.MYSQL_USER_IAM }}"

--- a/build.sh
+++ b/build.sh
@@ -111,12 +111,34 @@ EOF
   done
 }
 
+# Helper to perform authenticated curl requests to GitHub API if token is present
+function gh_curl() {
+  local auth_header=()
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
+  elif [[ -n "${GH_TOKEN:-}" ]]; then
+    auth_header=(-H "Authorization: Bearer $GH_TOKEN")
+  fi
+  curl -s "${auth_header[@]}" "$@"
+}
+
 # Download the protoc tool if it's not already installed.
 function get_protoc() {
   # Find the latest version of protoc
-  protoc_version=$(curl -s "https://api.github.com/repos/protocolbuffers/protobuf/releases/latest" | jq -r '.tag_name' | sed 's/v//')
-  proto_go_version=$(curl -s "https://api.github.com/repos/protocolbuffers/protobuf-go/releases/latest" | jq -r '.tag_name' | sed 's/v//')
-  proto_grpc_go_version=$(curl -s "https://api.github.com/repos/grpc/grpc-go/releases" | jq -r '.[].tag_name' | grep cmd/protoc-gen-go-grpc | sed 's|cmd/protoc-gen-go-grpc/v||' | head -n1)
+  protoc_version=$(gh_curl "https://api.github.com/repos/protocolbuffers/protobuf/releases/latest" | jq -r 'if type=="object" and .tag_name then .tag_name else empty end' 2>/dev/null | sed 's/v//' || true)
+  if [[ -z "$protoc_version" ]]; then
+    protoc_version="35.1"
+  fi
+
+  proto_go_version=$(gh_curl "https://api.github.com/repos/protocolbuffers/protobuf-go/releases/latest" | jq -r 'if type=="object" and .tag_name then .tag_name else empty end' 2>/dev/null | sed 's/v//' || true)
+  if [[ -z "$proto_go_version" ]]; then
+    proto_go_version="1.36.11"
+  fi
+
+  proto_grpc_go_version=$(gh_curl "https://api.github.com/repos/grpc/grpc-go/releases" | jq -r 'if type=="array" then .[].tag_name else empty end' 2>/dev/null | grep cmd/protoc-gen-go-grpc | sed 's|cmd/protoc-gen-go-grpc/v||' | head -n1 || true)
+  if [[ -z "$proto_grpc_go_version" ]]; then
+    proto_grpc_go_version="1.6.2"
+  fi
 
   mkdir -p "$SCRIPT_DIR/.tools"
   versioned_cmd="$SCRIPT_DIR/.tools/protoc-$protoc_version"
@@ -207,8 +229,10 @@ function get_golang_tool() {
   github_repo="$2"
   package="$3"
   set -x
-  # Download goimports tool
-  version=$(curl -s "https://api.github.com/repos/$github_repo/tags" | jq -r '.[].name' | head -n 1)
+  version=$(gh_curl "https://api.github.com/repos/$github_repo/tags" | jq -r 'if type=="array" then .[0].name else empty end' 2>/dev/null || true)
+  if [[ -z "$version" || "$version" == "null" ]]; then
+    version="latest"
+  fi
   mkdir -p "$SCRIPT_DIR/.tools"
   cmd="$SCRIPT_DIR/.tools/$name"
   versioned_cmd="$SCRIPT_DIR/.tools/$name-$version"


### PR DESCRIPTION
## Title
fix: handle GitHub API rate limiting in build script and workflows

## Description

### Context & Problem
When running CI jobs (e.g., `./build.sh e2e_ci` or `./build.sh lint_ci`) or building locally, `build.sh` queries the GitHub REST API (such as `api.github.com/repos/.../tags`) to discover tool versions.

When unauthenticated API requests hit GitHub's 60 req/hr rate limit per IP, GitHub returns an error JSON payload (`{"message": "API rate limit exceeded..."}`). 
Piping this response into `jq -r '.[].name'` resulted in the following error:
```text
jq: error (at <stdin>:1): Cannot index string with string ("name")
