### PR TITLE
fix: Address code review comments on PSC DNS error handling

### DIFF
--- a/instance/conn_name.go
+++ b/instance/conn_name.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"cloud.google.com/go/cloudsqlconn/errtype"
 )
@@ -29,6 +30,9 @@ var (
 	connNameRegex = regexp.MustCompile("([^:]+(:[^:]+)?):([^:]+):([^:]+)")
 	// The domain name pattern in accordance with RFC 1035, RFC 1123 and RFC 2181.
 	domainNameRegex = regexp.MustCompile(`^(?:[_a-z0-9](?:[_a-z0-9-]{0,61}[a-z0-9])?\.)+(?:[a-z](?:[a-z0-9-]{0,61}[a-z0-9])?)?$`)
+
+	instanceDNSSuffixRegex = regexp.MustCompile(`\.sql(-[a-zA-Z0-9_]+)?\.goog\.?$`)
+	globalInstanceDNSRegex = regexp.MustCompile(`\.global\.sql(-[a-zA-Z0-9_]+)?\.goog\.?$`)
 )
 
 // ConnName represents the "instance connection name", in the format
@@ -117,4 +121,61 @@ type ConnectionNameResolver interface {
 	// connection string for the name. If the name cannot be resolved, returns
 	// an error.
 	Resolve(ctx context.Context, name string) (ConnName, error)
+}
+
+// ParseInstanceDNSName parses a DNS name into its constituent parts.
+// Instance DNS names follow this template:
+// {instance-dns-label}.{project-dns-label}.{cloud-region}.{dns-suffix}
+// Suffix is one of: sql.goog, sql-psa.goog, sql-psc.goog (with optional trailing dot).
+// This returns ok == false when the region is "global"
+func ParseInstanceDNSName(dnsName string) (instanceLabel, projectLabel, region, suffix string, ok bool) {
+	dnsName = strings.TrimSuffix(dnsName, ".")
+	dnsName = strings.ToLower(dnsName)
+
+	parts := strings.Split(dnsName, ".")
+	if len(parts) != 5 {
+		return "", "", "", "", false
+	}
+
+	if parts[4] != "goog" {
+		return "", "", "", "", false
+	}
+
+	suffixType := parts[3]
+	if suffixType != "sql" && suffixType != "sql-psa" && suffixType != "sql-psc" {
+		return "", "", "", "", false
+	}
+
+	instanceLabel = parts[0]
+	projectLabel = parts[1]
+	region = parts[2]
+	suffix = suffixType + ".goog"
+
+	// Validate region != "global". "global" is used for redirect to write endpoint DNS
+	if region == "global" {
+		return "", "", "", "", false
+	}
+
+	// Validate labels
+	if len(instanceLabel) != 12 {
+		return "", "", "", "", false
+	}
+	for _, c := range instanceLabel {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return "", "", "", "", false
+		}
+	}
+
+	if !strings.Contains(region, "-") {
+		return "", "", "", "", false
+	}
+
+	return instanceLabel, projectLabel, region, suffix, true
+}
+
+// IsInstanceDNSName returns true if the domain name matches the well-known
+// Cloud SQL instance DNS name pattern.
+func IsInstanceDNSName(dnsName string) bool {
+	dnsName = strings.ToLower(dnsName)
+	return instanceDNSSuffixRegex.MatchString(dnsName) && !globalInstanceDNSRegex.MatchString(dnsName)
 }

--- a/internal/cloudsql/resolver.go
+++ b/internal/cloudsql/resolver.go
@@ -88,7 +88,7 @@ func (r *dnsInstanceConnectionNameResolver) Resolve(ctx context.Context, icn str
 	var txtErr error
 	for depth := 0; depth < 10; depth++ {
 		// Check if it matches the well-known DNS pattern directly
-		if _, _, region, _, ok := parseInstanceDNSName(current); ok {
+		if _, _, region, _, ok := instance.ParseInstanceDNSName(current); ok {
 			dnsNameWithDot := current
 			if !strings.HasSuffix(dnsNameWithDot, ".") {
 				dnsNameWithDot += "."
@@ -134,7 +134,7 @@ func (r *dnsInstanceConnectionNameResolver) Resolve(ctx context.Context, icn str
 		current = cnameVal
 	}
 
-	return instance.ConnName{}, fmt.Errorf("cname lookup limit exceeded (max 10) for %q", icn)
+	return instance.ConnName{}, errtype.NewConfigError(fmt.Sprintf("cname lookup limit exceeded (max 10) for %q", icn), icn)
 }
 
 // queryDNS attempts to resolve a TXT record for the domain name.
@@ -183,54 +183,4 @@ func (r *dnsInstanceConnectionNameResolver) queryDNS(ctx context.Context, domain
 
 	// No records were found, return an error.
 	return instance.ConnName{}, fmt.Errorf("no valid TXT records found for %q", domainName)
-}
-
-// parseInstanceDNSName parses a DNS name into its constituent parts.
-// Instance DNS names follow this template:
-// {instance-dns-label}.{project-dns-label}.{cloud-region}.{dns-suffix}
-// Suffix is one of: sql.goog, sql-psa.goog, sql-psc.goog (with optional trailing dot).
-// This returns ok == false when the region is "global"
-func parseInstanceDNSName(dnsName string) (instanceLabel, projectLabel, region, suffix string, ok bool) {
-	dnsName = strings.TrimSuffix(dnsName, ".")
-	dnsName = strings.ToLower(dnsName)
-
-	parts := strings.Split(dnsName, ".")
-	if len(parts) != 5 {
-		return "", "", "", "", false
-	}
-
-	if parts[4] != "goog" {
-		return "", "", "", "", false
-	}
-
-	suffixType := parts[3]
-	if suffixType != "sql" && suffixType != "sql-psa" && suffixType != "sql-psc" {
-		return "", "", "", "", false
-	}
-
-	instanceLabel = parts[0]
-	projectLabel = parts[1]
-	region = parts[2]
-	suffix = suffixType + ".goog"
-
-	// Validate region != "global". "global" is used for redirect to write endpoint DNS
-	if region == "global" {
-		return "", "", "", "", false
-	}
-
-	// Validate labels
-	if len(instanceLabel) != 12 {
-		return "", "", "", "", false
-	}
-	for _, c := range instanceLabel {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
-			return "", "", "", "", false
-		}
-	}
-
-	if !strings.Contains(region, "-") {
-		return "", "", "", "", false
-	}
-
-	return instanceLabel, projectLabel, region, suffix, true
 }

--- a/monitored_cache.go
+++ b/monitored_cache.go
@@ -16,12 +16,15 @@ package cloudsqlconn
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"cloud.google.com/go/cloudsqlconn/debug"
+	"cloud.google.com/go/cloudsqlconn/errtype"
 	"cloud.google.com/go/cloudsqlconn/instance"
+	"google.golang.org/api/googleapi"
 )
 
 // monitoredCache is a wrapper around a connectionInfoCache that tracks the
@@ -58,7 +61,7 @@ func newMonitoredCache(
 		logger:              logger,
 		connectionInfoCache: cache,
 	}
-	if cn.HasDomainName() {
+	if cn.HasDomainName() && !instance.IsInstanceDNSName(cn.DomainName()) {
 		c.domainNameTicker = time.NewTicker(failoverPeriod)
 		go func() {
 			dnCheckCtx, cancelFn := context.WithCancel(context.Background())
@@ -130,11 +133,16 @@ func (c *monitoredCache) checkDomainName(ctx context.Context) {
 	}
 	newCn, err := c.resolver.Resolve(ctx, c.cn.DomainName())
 	if err != nil {
-		// The domain name could not be resolved.
-		c.logger.Debugf(ctx, "domain name %s for instance %s did not resolve, "+
-			"closing all connections: %v",
-			c.cn.DomainName(), c.cn.Name(), err)
-		c.Close()
+		if isNonTransient(err) {
+			c.logger.Debugf(ctx, "domain name %s for instance %s failed with non-transient error, "+
+				"closing all connections: %v",
+				c.cn.DomainName(), c.cn.Name(), err)
+			c.Close()
+		} else {
+			c.logger.Debugf(ctx, "domain name %s did not resolve (transient error), keeping connections: %v",
+				c.cn.DomainName(), err)
+		}
+		return
 	}
 	if newCn != c.cn {
 		// The instance changed.
@@ -144,4 +152,21 @@ func (c *monitoredCache) checkDomainName(ctx context.Context) {
 		c.Close()
 	}
 
+}
+
+func isNonTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+	var confErr *errtype.ConfigError
+	if errors.As(err, &confErr) {
+		return true
+	}
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) {
+		if apiErr.Code == 403 || apiErr.Code == 404 {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This PR addresses code review comments on PSC DNS error handling:
- Update IsInstanceDNSName regex to match /.sql(-\w+)?.goog$/ and exclude /.global.sql(-\w+)?.goog$/
- Use specific error types/codes instead of checking error message strings for CNAME loops
- Disable periodic resolution for immutable instance DNS names
- Distinguish transient vs non-transient errors in monitored cache